### PR TITLE
updates desktop file

### DIFF
--- a/resources/metadata/luppp.desktop
+++ b/resources/metadata/luppp.desktop
@@ -1,14 +1,13 @@
 [Desktop Entry]
-Version=1.0
 Name=Luppp
 GenericName=Live performance mixing tool
 GenericName[fr]=Outil de mixage pour performance live
 Comment=Create music by recording, playing, and mixing samples
-Comment[fr]=Créer de la musique en enregistrant, jouant et mixant des échantillons
+Comment[fr]=Créer de la musique en enregistrant, jouant, et mixant des échantillons
 Type=Application
 Categories=Audio;AudioVideo;
 Exec=luppp
 Terminal=false
 StartupNotify=true
-Icon=/usr/share/luppp/luppp.png
+Icon=luppp
 X-NSM-capable=true


### PR DESCRIPTION
I'm quite sure that the version thing is non needed. Please correct me if I'm wrong.
A little French line improvement.
The icon place is up to the packager I guess. That said, I'm not sure it doesn't conflict with a personal compilation. If that can be helpful, I know that in Debian, the icons are to be put under /usr/share/pixmaps/ .

Hope that helps and, please @harryhaaren, feel free to ask some change to this PR.
