### PR TITLE
Fix loading of pan values

### DIFF
--- a/src/diskreader.cxx
+++ b/src/diskreader.cxx
@@ -615,7 +615,7 @@ int DiskReader::readTracks()
 					if( !pan ) {
 						LUPPP_WARN("Track %i has no pan data saved.", t);
 					} else {
-						EventTrackPan e( t, pan->valuedouble );
+						EventTrackPan e( t, (pan->valuedouble*2)-1.f );
 						writeToDspRingbuffer( &e );
 						LUPPP_WARN("Track %i has pan %f", pan->valuedouble);
 					}


### PR DESCRIPTION
The pan dial uses values of the interval [-1, 1]. These values are converted to an interval of [0, 1] by gtrack.hxx:70. When reading pan values from a saved file, a reversed conversion needs to be done.

This is currently not the case but will be done by this PR. It fixes #168.