### PR TITLE
Add Meson build system integration

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,36 @@
+project('openav_luppp', ['c','cpp'])
+
+conf_data = configuration_data()
+conf_data.set('version', '1.1.1')
+
+#add_project_arguments('-std=c99', language : 'c')
+#add_project_arguments('-std=c++11', language : 'cpp')
+add_project_arguments('-Wno-unused-variable', language : 'cpp')
+add_project_arguments('-Wno-reorder', language : 'cpp')
+add_project_arguments('-Wno-sign-compare', language : 'cpp')
+
+cc  = meson.get_compiler('c')
+cpp = meson.get_compiler('cpp')
+
+luppp_src = []
+subdir('src')
+
+
+dep_names = [
+  'ntk',
+  'cairo',
+  'liblo',
+  'jack',
+  'sndfile',
+  'samplerate',
+  'x11'
+  ]
+deps = []
+
+foreach dep : dep_names
+  deps += dependency(dep)
+endforeach
+
+# compile the main project
+executable('luppp', luppp_src,
+    dependencies: deps)

--- a/meson.build
+++ b/meson.build
@@ -1,10 +1,16 @@
-project('openav_luppp', ['c','cpp'])
+project( 'openav_luppp', ['c','cpp'],
+  default_options : [
+    'cpp_std=c++11',
+    ])
 
 conf_data = configuration_data()
 conf_data.set('version', '1.1.1')
 
-#add_project_arguments('-std=c99', language : 'c')
-#add_project_arguments('-std=c++11', language : 'cpp')
+
+if(get_option('tests') == true)
+  add_project_arguments('-DBUILD_TESTS', language : 'cpp')
+endif
+
 add_project_arguments('-Wno-unused-variable', language : 'cpp')
 add_project_arguments('-Wno-reorder', language : 'cpp')
 add_project_arguments('-Wno-sign-compare', language : 'cpp')

--- a/meson.build
+++ b/meson.build
@@ -38,5 +38,5 @@ foreach dep : dep_names
 endforeach
 
 # compile the main project
-executable('luppp', luppp_src,
+executable('luppp', luppp_src + [version_hxx],
     dependencies: deps)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('tests', type : 'boolean', value : true, description : 'Build tests')

--- a/src/avtk/meson.build
+++ b/src/avtk/meson.build
@@ -1,0 +1,1 @@
+luppp_src += files( 'bindings.cxx', 'volume.cxx', 'clipselector.cxx')

--- a/src/cjson/meson.build
+++ b/src/cjson/meson.build
@@ -1,0 +1,1 @@
+luppp_src += files('cJSON.c')

--- a/src/controller/meson.build
+++ b/src/controller/meson.build
@@ -1,0 +1,6 @@
+luppp_src += files(
+  'controller.cxx',
+  'genericmidi.cxx',
+  'guicontroller.cxx',
+  'nonseq.cxx'
+)

--- a/src/dsp/meson.build
+++ b/src/dsp/meson.build
@@ -1,0 +1,1 @@
+luppp_src += files('dsp_sidechain_gain.cxx')

--- a/src/meson.build
+++ b/src/meson.build
@@ -30,3 +30,7 @@ subdir('controller')
 subdir('observer')
 subdir('state')
 subdir('avtk')
+
+if(get_option('tests') == true)
+  subdir('tests')
+endif

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,0 +1,32 @@
+luppp_src = files(
+  'audiobuffer.cxx',
+  'controllerupdater.cxx',
+  'debug.cxx',
+  'diskreader.cxx',
+  'diskwriter.cxx',
+  'event.cxx',
+  'eventhandlerdsp.cxx',
+  'eventhandlergui.cxx',
+  'gaudioeditor.cxx',
+  'gmastertrack.cxx',
+  'goptions.cxx',
+  'gridlogic.cxx',
+  'gtrack.cxx',
+  'gui.cxx',
+  'jack.cxx',
+  'jacksendreturn.cxx',
+  'logic.cxx',
+  'looperclip.cxx',
+  'looper.cxx',
+  'main.cxx',
+  'metronome.cxx',
+  'timemanager.cxx',
+  'trackoutput.cxx'
+  )
+
+subdir('cjson')
+subdir('dsp')
+subdir('controller')
+subdir('observer')
+subdir('state')
+subdir('avtk')

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,3 +1,7 @@
+version_hxx = vcs_tag(
+    input  : 'version.hxx.in',
+    output : 'version.hxx')
+
 luppp_src = files(
   'audiobuffer.cxx',
   'controllerupdater.cxx',

--- a/src/observer/meson.build
+++ b/src/observer/meson.build
@@ -1,0 +1,1 @@
+luppp_src += files('midi.cxx', 'time.cxx')

--- a/src/state/meson.build
+++ b/src/state/meson.build
@@ -1,0 +1,1 @@
+luppp_src += files('state.cxx', 'stately.cxx')

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -1,0 +1,5 @@
+luppp_src += files(
+  'diskreadertest.cxx',
+  'diskwritertest.cxx',
+  'goptionstest.cxx',
+  'gridlogictests.cxx')

--- a/src/version.hxx.in
+++ b/src/version.hxx.in
@@ -1,0 +1,1 @@
+#define GIT_VERSION "@VCS_TAG@"


### PR DESCRIPTION
This PR enables Luppp to be built with Meson. The build files are simpler and much more readable than CMake, which should ensure builds are more consistent and that testing of builds with its options is better covered.