### PR TITLE
update all scene launch buttons

### DIFF
--- a/src/controller/genericmidi.cxx
+++ b/src/controller/genericmidi.cxx
@@ -609,19 +609,18 @@ void GenericMIDI::launchScene( int scene )
 		Binding* b = actionToMidi.at(i);
 
 		if ( b->action == GRID_LAUNCH_SCENE ) {
-			for( int i = 0; i < 5; i++ ) {
-				if ( i != scene ) {
-					unsigned char data[3];
-					data[0] = b->status;
-					data[1] = b->data + i;
-					data[2] = 0;
-					writeMidi( data );
-				}
-			}
 			unsigned char data[3];
 			data[0] = b->status;
-			data[1] = b->data + scene;
-			data[2] = 127;
+			data[1] = b->data + i;
+			
+			if ( i != scene ) 
+			{
+				data[2] = 0;
+			} 
+			else 
+			{
+				data[2] = 127;
+			}
 			//LUPPP_NOTE("this = %i GenericMIDI::launchScene()", this );
 			writeMidi( data );
 


### PR DESCRIPTION
I filed this before, but now its clean and i will describe the exact behavior to be sure there is no error in thinking.

The old behavior:
scene launch is triggered
Loop over all specified midi bindings
    if the current binding is a scene launch
    loop from 0 to 5
        if i is not the scene which is activated
            send note off to 5 adresses after the first found scene launch binding

This has the problem that it only works for 5 scenes and only if the midi adresses of the used buttons are following each other, eg 0,1,2,3,4. If the adresses are in an other order, it wont work since the function returns after the first found scene launch binding.

The new behavior is:
scene launch is triggered
Loop over all specified midi bindings
    if the current binding is a scene launch
        if it is the triggered scene launch turn it on
        else turn it off

in my opinion this is much easier, more flexible and allows more than 5 scene launch buttons on any controller. I use this code since over a year now and didnt had any problems. Would be happy if this could be merged into Luppp.