### PR TITLE
Ctlra v1

### DIFF
--- a/gcc/ctlra_test.c
+++ b/gcc/ctlra_test.c
@@ -31,6 +31,14 @@ int test_ctlra(int num, struct ctlra_event_t **events)
 			case 22: mode = MODE_PATTERN; break;
 			case 23: mode = MODE_PAD; break;
 			case 24: if(shift) mode = MODE_VOLUME; break;
+
+			case 63: printf("ecndoer press\n");
+				struct event_grid_launch_scene ev = {
+					4
+				};
+				luppp_do(EVENT_GRID_LAUNCH_SCENE, &ev);
+				break;
+
 			default: printf("button %d\n", id); break;
 			}
 			break;

--- a/gcc/ctlra_test.c
+++ b/gcc/ctlra_test.c
@@ -24,6 +24,7 @@ int test_ctlra(int num, struct ctlra_event_t **events)
 		switch(e->type) {
 		case CTLRA_EVENT_BUTTON: {
 			int id = e->button.id;
+			printf("button id = %d\n", id);
 			switch(id) {
 			case 7: shift = e->button.pressed; break;
 			case 21: mode = MODE_SCENE; break;

--- a/gcc/ctlra_test.c
+++ b/gcc/ctlra_test.c
@@ -1,0 +1,207 @@
+#include "luppp_script_api.h"
+
+#include "pstdint.h"
+
+#include "event.h"
+
+
+#define MODE_SCENE 0
+#define MODE_PATTERN 1
+#define MODE_PAD 2
+#define MODE_VOLUME 3
+
+static int mode;
+static int shift;
+static float volumes[4];
+
+int test_ctlra(int num, struct ctlra_event_t **events)
+{
+	//printf("test_ctlra\n");
+	for(uint32_t i = 0; i < num; i++) {
+		const char *pressed = 0;
+		struct ctlra_event_t *e = events[i];
+		const char *name = 0;
+		switch(e->type) {
+		case CTLRA_EVENT_BUTTON: {
+			int id = e->button.id;
+			switch(id) {
+			case 7: shift = e->button.pressed; break;
+			case 21: mode = MODE_SCENE; break;
+			case 22: mode = MODE_PATTERN; break;
+			case 23: mode = MODE_PAD; break;
+			case 24: if(shift) mode = MODE_VOLUME; break;
+			default: printf("button %d\n", id); break;
+			}
+			break;
+		}
+
+		case CTLRA_EVENT_GRID: {
+			int pos = e->grid.pos;
+			//printf("grid id = %d, pos %d, pressed %d\n", e->grid.id, e->grid.pos, e->grid.pressed);
+			if(mode == MODE_VOLUME) {
+				static float vols[] = {1, 0.5, 0.3, 0.15};
+				int t = e->grid.pos % 4;
+				float v = vols[e->grid.pos / 4];
+				struct event_track_volume ev = {t, v};
+				volumes[t] = v;
+				luppp_do(EVENT_TRACK_VOLUME, &ev);
+			}
+			if(mode == MODE_SCENE) {
+				struct event_grid_launch_scene ev =
+					{e->grid.pos / 4};
+				luppp_do(EVENT_GRID_LAUNCH_SCENE, &ev);
+			}
+			if(mode == MODE_PATTERN) {
+				int t = e->grid.pos % 4;
+				int s = e->grid.pos / 4;
+				struct event_grid_press_release ev =
+					{t, s, e->grid.pressed};
+				luppp_do(EVENT_GRID_PRESS_RELEASE, &ev);
+			}
+			break;
+		}
+
+		case CTLRA_EVENT_SLIDER: {
+			int id = e->slider.id;
+			//printf("slider %d\n", id);
+			if(id < 4) {
+				struct event_track_volume ev = {
+					.track = id,
+					.value = e->slider.value,
+				};
+				luppp_do(EVENT_TRACK_VOLUME, &ev);
+			} else {
+				struct event_track_send ev = {
+					.track = id - 4,
+					.send = 0,
+					.value = e->slider.value,
+				};
+				luppp_do(EVENT_TRACK_SEND, &ev);
+			}
+			break;
+		}
+		} /* switch */
+	}
+}
+
+int test_poll(unsigned char* midi)
+{
+	if(midi[1] == 0x42) {
+		printf("play pressed\n");
+	}
+	if(midi[1] == 0x3c) {
+		printf("cue pressed\n");
+	}
+	if(midi[1] == 0x3b) {
+		printf("demo pressed\n");
+	}
+	if(midi[1] == 0x33) {
+		printf("33 pressed\n");
+	}
+	if(midi[1] == 0x47) {
+		printf("47 pressed\n");
+	}
+	if(midi[1] == 0x66) {
+		printf("66 pressed - sending track active\n");
+		struct event_track_send_active e = {
+			.track = 3,
+			.send = 0,
+			.active = midi[0] == 0x90,
+		};
+		luppp_do(EVENT_TRACK_SEND_ACTIVE, &e);
+	}
+
+	static int lookup[0x17];
+	lookup[0x8 ] = 0;
+	lookup[0x17] = 1;
+	lookup[0xb ] = 2;
+	lookup[0x9 ] = 3;
+
+	if(midi[0] == 0xb0) {
+		if(midi[1] == 0x17 ||
+		   midi[1] == 0x8  ||
+		   midi[1] == 0xb  ||
+		   midi[1] == 0x9) {
+			struct event_track_send e = {
+				.track = lookup[midi[1]],
+				.send = 0,
+				.value = midi[2] / 127.f,
+			};
+			luppp_do(EVENT_TRACK_SEND, &e);
+		}
+
+		if(midi[1] == 0xd || midi[1] == 0xe) {
+			struct event_track_volume e = {
+				.track = (midi[1] == 0xe),
+				.value = midi[2] / 127.f,
+			};
+			luppp_do(EVENT_TRACK_VOLUME, &e);
+		}
+	}
+	
+	return 0;
+}
+
+void test_handle(void *ctlr, enum EVENT_ID id, void *event)
+{
+	switch(id) {
+	case EVENT_TRACK_SEND_ACTIVE: {
+		struct event_track_send_active *e =
+			(struct event_track_send_active *)event;
+		//printf("Script t %d, s %d, active %d\n", e->track, e->send, e->active);
+		unsigned char led_on [3] = {0x90, 0x42, 0x7F};
+		unsigned char led_off[3] = {0x80, 0x42, 0};
+#if 0
+		if(e->active)
+			//luppp_write_midi(ctlr, led_on);
+		else
+			//luppp_write_midi(ctlr, led_off);
+#endif
+		} break;
+	case EVENT_GRID_PRESS_RELEASE: {
+		struct event_grid_press_release *e =
+			(struct event_grid_press_release *)event;
+		//printf("pressed = %d\n", e->pressed);
+		uint32_t col[] = {
+			0xff000000,
+			0x0000ff00,
+			0x000041ff,
+			0x00ff5100,
+			0x000041ff,
+			0x00ff0000,
+			0x0000ffff,
+		};
+		if(e->track > 3 || e->scene > 3)
+			break;
+		int light = (e->scene * 4) + e->track + 28;
+		//printf("light = %d\n", light);
+		luppp_write_ctlra_light(ctlr, light, col[e->pressed]);
+		} break;
+	case EVENT_TIME_BAR_BEAT: {
+		struct event_time_bar_beat *e =
+			(struct event_time_bar_beat *)event;
+		//printf("Script bar %d, beat %d\n", e->bar, e->beat);
+		int on = e->beat % 4;
+		int off = (e->beat+3) % 4;
+		uint32_t ids[] = {16, 13, 14, 19};
+		luppp_write_ctlra_light(ctlr, ids[on], UINT32_MAX);
+		int i;
+		for(i = on; i < 3; i++)
+			luppp_write_ctlra_light(ctlr, ids[off-i], 0x4000000);
+		} break;
+	};
+
+	/* TODO: port this to the feedback API: handle "other" stuff */
+	luppp_write_ctlra_light(ctlr, 20, (mode == MODE_SCENE) * UINT32_MAX);
+	luppp_write_ctlra_light(ctlr, 21, (mode == MODE_PATTERN) * UINT32_MAX);
+	luppp_write_ctlra_light(ctlr, 22, (mode == MODE_PAD) * UINT32_MAX);
+
+	luppp_write_ctlra_light(ctlr, 23, (mode == MODE_VOLUME) * UINT32_MAX);
+	if(mode == MODE_VOLUME) {
+		const float levels[] = {1, 0.5, 0.3, 0.15};
+		for(int j = 0; j < 4; j++)
+			for(int i = 0; i < 4; i++)
+				luppp_write_ctlra_light(ctlr, 28 + j + i * 4,
+					(volumes[j] >= levels[i]) * UINT32_MAX);
+	}
+}

--- a/gcc/event.h
+++ b/gcc/event.h
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2016, OpenAV Productions,
+ * Harry van Haaren <harryhaaren@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef OPENAV_CTLRA_EVENT
+#define OPENAV_CTLRA_EVENT
+
+/** @file
+ * Event header of the Ctlra library. These events provide a generic
+ * interface which is used to send events from hardware devices to the
+ * software application. These events describe any action - if a device
+ * has an action that cannot be currently described, please contact OpenAV
+ * or send a patch to propose a solution. Thanks!
+ */
+
+/** Types of events */
+enum ctlra_event_type_t {
+	/* The order of these events must not be modified */
+	CTLRA_EVENT_BUTTON = 0,
+	CTLRA_EVENT_ENCODER,
+	CTLRA_EVENT_SLIDER,
+	CTLRA_EVENT_GRID,
+	/* Feedback items represent items like LEDs */
+	CTLRA_FEEDBACK_ITEM,
+	/* The number of event types there are */
+	CTLRA_EVENT_T_COUNT,
+};
+
+/* defined in event.c */
+extern const char *ctlra_event_type_names[];
+
+struct ctlra_dev_t;
+
+/** Represents a button. */
+struct ctlra_event_button_t {
+	/** The id of the button */
+	uint32_t id;
+	/** The state of the button */
+	uint8_t pressed : 1;
+	uint8_t has_pressure : 1;
+	uint8_t unused : 6;
+	/** Pressure or velocity of the button press/release */
+	float pressure;
+};
+
+#define CTLRA_EVENT_ENCODER_FLAG_INT   (1<<0)
+#define CTLRA_EVENT_ENCODER_FLAG_FLOAT (1<<1)
+
+/** Represents an endless stepped controller. */
+struct ctlra_event_encoder_t {
+	/** The id of the encoder */
+	uint32_t id;
+	/** This flag indicates if the encoder is sending an integer or
+	 * floating point delta increment.
+	 *
+	 * "Stepped" rotary encoders (such as those used to navigate
+	 * song libraries etc) will use the integer delta, with a single
+	 * step being the smallest delta.
+	 *
+	 * Endless encoders (without notches) use the floating point delta
+	 * and the application may interpret the range of the delta as
+	 *  1.0f : one full clockwise rotation (360 deg)
+	 * -1.0f : one full anti-clockwise rotation (-360 deg)
+	 *
+	 * When explicitly scripting support for a controller, the actual
+	 * encoder ID itself will already know which type it is - but for
+	 * generic handling of any controller, this int/float metadata is
+	 * required for correct handling of the values.
+	 */
+	uint8_t flags;
+	union {
+		/** Positive values indicate clockwise rotation, and vice-versa */
+		int32_t delta;
+		float   delta_float;
+	};
+};
+
+/** Represents a fader or dial with a fixed range of movement. */
+struct ctlra_event_slider_t {
+	/** The id of the slider */
+	uint32_t id;
+	/** Absolute position of the control */
+	float value;
+};
+
+#define CTLRA_EVENT_GRID_FLAG_BUTTON   (1<<0)
+#define CTLRA_EVENT_GRID_FLAG_PRESSURE (1<<1)
+
+/** Represents a grid of buttons */
+struct ctlra_event_grid_t {
+	/** The ID of the grid */
+	uint32_t id;
+	/** Flags: set if pressure or button, see defines above */
+	uint16_t flags;
+	/** The position of the square in the grid */
+	uint16_t pos;
+	/** The pressure component of the grid, range from 0.f to 1.f */
+	float pressure;
+	/** The state of the button component of the square. Pressed
+	 * should only be set once when the state is considered changed.
+	 * This makes handling note-events from a grid easier */
+	uint32_t pressed;
+};
+
+/** The event passed around in the API */
+struct ctlra_event_t {
+	/** The type of this event */
+	enum ctlra_event_type_t type;
+
+	/** The event data: see examples/ dir for examples of usage */
+	union {
+		struct ctlra_event_button_t button;
+		struct ctlra_event_encoder_t encoder;
+		struct ctlra_event_slider_t slider;
+		struct ctlra_event_grid_t grid;
+	};
+};
+
+/** Callback function that is called for event(s) */
+typedef void (*ctlra_event_func)(struct ctlra_dev_t* dev,
+				uint32_t num_events,
+				struct ctlra_event_t** event,
+				void *userdata);
+
+/** Callback function that is called to update the feedback on the device,
+ * eg for leds, buttons and screens */
+typedef void (*ctlra_feedback_func)(struct ctlra_dev_t *dev,
+				    void *userdata);
+
+#endif /* OPENAV_CTLRA_EVENT */

--- a/gcc/luppp_script_api.h
+++ b/gcc/luppp_script_api.h
@@ -1,0 +1,111 @@
+/*
+ * Author: Harry van Haaren 2018
+ *         harryhaaren@gmail.com
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#ifndef LUPPP_SCRIPT_API_H
+#define LUPPP_SCRIPT_API_H
+
+/**
+ * This file is the API for the Controller Scripts, allowing them to
+ * understand the events that have occurred in Luppp, and should be shown
+ * on the hardware device. Similarly, this API provides functions to send
+ * events to Luppp, which allow controlling of Luppp from the hardware.
+ */
+
+enum EVENT_ID {
+	EVENT_NOP = 0,
+	/* Track Events */
+	EVENT_TRACK_RECORD_ARM,
+	EVENT_TRACK_VOLUME,
+	EVENT_TRACK_SEND,
+	EVENT_TRACK_SEND_ACTIVE,
+	EVENT_TRACK_JACKSEND,
+	EVENT_TRACK_JACKSEND_ACTIVE,
+	/* Grid Events */
+	EVENT_GRID_PRESS_RELEASE,
+	EVENT_GRID_LAUNCH_SCENE,
+	/* Tempo Events */
+	EVENT_TEMPO_BPM,
+	EVENT_TEMPO_TAP,
+	/* Master Track */
+	EVENT_MASTER_VOLUME,
+	EVENT_MASTER_RETURN,
+	/* Time */
+	EVENT_TIME_BAR_BEAT,
+};
+
+struct event_track_record_arm {
+	int track;
+	int armed;
+};
+struct event_track_jack_send {
+	int track;
+	float value;
+};
+struct event_track_jack_send_active {
+	int track;
+	int active;
+};
+struct event_track_volume {
+	int track;
+	float value;
+};
+struct event_track_send {
+	int track;
+	int send;
+	float value;
+};
+struct event_track_send_active {
+	int track;
+	int send;
+	int active;
+};
+struct event_grid_launch_scene {
+	int scene;
+};
+struct event_grid_press_release {
+	int track;
+	int scene;
+	int pressed;
+};
+struct event_tempo_bpm {
+	float bpm;
+};
+struct event_tempo_tap {
+	int pressed; /* can be used to turn controller LED on/off */
+};
+struct event_master_volume {
+	float volume;
+};
+struct event_master_return {
+	float volume;
+};
+
+/* Read only events : aka, sending to Luppp won't have any effect. These
+ * are used only so controllers can display status from Luppp */
+struct event_time_bar_beat {
+	int bar;
+	int beat;
+};
+
+void luppp_do(enum EVENT_ID id, void* event_struct);
+void luppp_write_midi(void *ctlr, unsigned char* midi);
+void luppp_write_ctlra_light(void *ctlr, int light, int light_status);
+
+#endif /* LUPPP_SCRIPT_API_H */
+

--- a/gcc/pstdint.h
+++ b/gcc/pstdint.h
@@ -1,0 +1,919 @@
+/*  A portable stdint.h
+ ****************************************************************************
+ *  BSD License:
+ ****************************************************************************
+ *
+ *  Copyright (c) 2005-2016 Paul Hsieh
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. The name of the author may not be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ *  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ *  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************
+ *
+ *  Version 0.1.16.0
+ *
+ *  The ANSI C standard committee, for the C99 standard, specified the
+ *  inclusion of a new standard include file called stdint.h.  This is
+ *  a very useful and long desired include file which contains several
+ *  very precise definitions for integer scalar types that is critically
+ *  important for making several classes of applications portable
+ *  including cryptography, hashing, variable length integer libraries
+ *  and so on.  But for most developers its likely useful just for
+ *  programming sanity.
+ *
+ *  The problem is that some compiler vendors chose to ignore the C99
+ *  standard and some older compilers have no opportunity to be updated.
+ *  Because of this situation, simply including stdint.h in your code
+ *  makes it unportable.
+ *
+ *  So that's what this file is all about.  It's an attempt to build a
+ *  single universal include file that works on as many platforms as
+ *  possible to deliver what stdint.h is supposed to.  Even compilers
+ *  that already come with stdint.h can use this file instead without
+ *  any loss of functionality.  A few things that should be noted about
+ *  this file:
+ *
+ *    1) It is not guaranteed to be portable and/or present an identical
+ *       interface on all platforms.  The extreme variability of the
+ *       ANSI C standard makes this an impossibility right from the
+ *       very get go. Its really only meant to be useful for the vast
+ *       majority of platforms that possess the capability of
+ *       implementing usefully and precisely defined, standard sized
+ *       integer scalars.  Systems which are not intrinsically 2s
+ *       complement may produce invalid constants.
+ *
+ *    2) There is an unavoidable use of non-reserved symbols.
+ *
+ *    3) Other standard include files are invoked.
+ *
+ *    4) This file may come in conflict with future platforms that do
+ *       include stdint.h.  The hope is that one or the other can be
+ *       used with no real difference.
+ *
+ *    5) In the current version, if your platform can't represent
+ *       int32_t, int16_t and int8_t, it just dumps out with a compiler
+ *       error.
+ *
+ *    6) 64 bit integers may or may not be defined.  Test for their
+ *       presence with the test: #ifdef INT64_MAX or #ifdef UINT64_MAX.
+ *       Note that this is different from the C99 specification which
+ *       requires the existence of 64 bit support in the compiler.  If
+ *       this is not defined for your platform, yet it is capable of
+ *       dealing with 64 bits then it is because this file has not yet
+ *       been extended to cover all of your system's capabilities.
+ *
+ *    7) (u)intptr_t may or may not be defined.  Test for its presence
+ *       with the test: #ifdef PTRDIFF_MAX.  If this is not defined
+ *       for your platform, then it is because this file has not yet
+ *       been extended to cover all of your system's capabilities, not
+ *       because its optional.
+ *
+ *    8) The following might not been defined even if your platform is
+ *       capable of defining it:
+ *
+ *       WCHAR_MIN
+ *       WCHAR_MAX
+ *       (u)int64_t
+ *       PTRDIFF_MIN
+ *       PTRDIFF_MAX
+ *       (u)intptr_t
+ *
+ *    9) The following have not been defined:
+ *
+ *       WINT_MIN
+ *       WINT_MAX
+ *
+ *   10) The criteria for defining (u)int_least(*)_t isn't clear,
+ *       except for systems which don't have a type that precisely
+ *       defined 8, 16, or 32 bit types (which this include file does
+ *       not support anyways). Default definitions have been given.
+ *
+ *   11) The criteria for defining (u)int_fast(*)_t isn't something I
+ *       would trust to any particular compiler vendor or the ANSI C
+ *       committee.  It is well known that "compatible systems" are
+ *       commonly created that have very different performance
+ *       characteristics from the systems they are compatible with,
+ *       especially those whose vendors make both the compiler and the
+ *       system.  Default definitions have been given, but its strongly
+ *       recommended that users never use these definitions for any
+ *       reason (they do *NOT* deliver any serious guarantee of
+ *       improved performance -- not in this file, nor any vendor's
+ *       stdint.h).
+ *
+ *   12) The following macros:
+ *
+ *       PRINTF_INTMAX_MODIFIER
+ *       PRINTF_INT64_MODIFIER
+ *       PRINTF_INT32_MODIFIER
+ *       PRINTF_INT16_MODIFIER
+ *       PRINTF_LEAST64_MODIFIER
+ *       PRINTF_LEAST32_MODIFIER
+ *       PRINTF_LEAST16_MODIFIER
+ *       PRINTF_INTPTR_MODIFIER
+ *
+ *       are strings which have been defined as the modifiers required
+ *       for the "d", "u" and "x" printf formats to correctly output
+ *       (u)intmax_t, (u)int64_t, (u)int32_t, (u)int16_t, (u)least64_t,
+ *       (u)least32_t, (u)least16_t and (u)intptr_t types respectively.
+ *       PRINTF_INTPTR_MODIFIER is not defined for some systems which
+ *       provide their own stdint.h.  PRINTF_INT64_MODIFIER is not
+ *       defined if INT64_MAX is not defined.  These are an extension
+ *       beyond what C99 specifies must be in stdint.h.
+ *
+ *       In addition, the following macros are defined:
+ *
+ *       PRINTF_INTMAX_HEX_WIDTH
+ *       PRINTF_INT64_HEX_WIDTH
+ *       PRINTF_INT32_HEX_WIDTH
+ *       PRINTF_INT16_HEX_WIDTH
+ *       PRINTF_INT8_HEX_WIDTH
+ *       PRINTF_INTMAX_DEC_WIDTH
+ *       PRINTF_INT64_DEC_WIDTH
+ *       PRINTF_INT32_DEC_WIDTH
+ *       PRINTF_INT16_DEC_WIDTH
+ *       PRINTF_UINT8_DEC_WIDTH
+ *       PRINTF_UINTMAX_DEC_WIDTH
+ *       PRINTF_UINT64_DEC_WIDTH
+ *       PRINTF_UINT32_DEC_WIDTH
+ *       PRINTF_UINT16_DEC_WIDTH
+ *       PRINTF_UINT8_DEC_WIDTH
+ *
+ *       Which specifies the maximum number of characters required to
+ *       print the number of that type in either hexadecimal or decimal.
+ *       These are an extension beyond what C99 specifies must be in
+ *       stdint.h.
+ *
+ *  Compilers tested (all with 0 warnings at their highest respective
+ *  settings): Borland Turbo C 2.0, WATCOM C/C++ 11.0 (16 bits and 32
+ *  bits), Microsoft Visual C++ 6.0 (32 bit), Microsoft Visual Studio
+ *  .net (VC7), Intel C++ 4.0, GNU gcc v3.3.3
+ *
+ *  This file should be considered a work in progress.  Suggestions for
+ *  improvements, especially those which increase coverage are strongly
+ *  encouraged.
+ *
+ *  Acknowledgements
+ *
+ *  The following people have made significant contributions to the
+ *  development and testing of this file:
+ *
+ *  Chris Howie
+ *  John Steele Scott
+ *  Dave Thorup
+ *  John Dill
+ *  Florian Wobbe
+ *  Christopher Sean Morrison
+ *  Mikkel Fahnoe Jorgensen
+ *
+ */
+
+#include <stddef.h>
+#include <limits.h>
+#include <signal.h>
+
+/*
+ *  For gcc with _STDINT_H, fill in the PRINTF_INT*_MODIFIER macros, and
+ *  do nothing else.  On the Mac OS X version of gcc this is _STDINT_H_.
+ */
+
+#if ((defined(__SUNPRO_C) && __SUNPRO_C >= 0x570) || (defined(_MSC_VER) && _MSC_VER >= 1600) || (defined(__STDC__) && __STDC__ && defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L) || (defined (__WATCOMC__) && (defined (_STDINT_H_INCLUDED) || __WATCOMC__ >= 1250)) || (defined(__GNUC__) && (__GNUC__ > 3 || defined(_STDINT_H) || defined(_STDINT_H_) || defined (__UINT_FAST64_TYPE__)) )) && !defined (_PSTDINT_H_INCLUDED)
+#include <stdint.h>
+#define _PSTDINT_H_INCLUDED
+# if defined(__GNUC__) && (defined(__x86_64__) || defined(__ppc64__)) && !(defined(__APPLE__) && defined(__MACH__))
+#  ifndef PRINTF_INT64_MODIFIER
+#   define PRINTF_INT64_MODIFIER "l"
+#  endif
+#  ifndef PRINTF_INT32_MODIFIER
+#   define PRINTF_INT32_MODIFIER ""
+#  endif
+# else
+#  ifndef PRINTF_INT64_MODIFIER
+#   define PRINTF_INT64_MODIFIER "ll"
+#  endif
+#  ifndef PRINTF_INT32_MODIFIER
+#   if (UINT_MAX == UINT32_MAX)
+#    define PRINTF_INT32_MODIFIER ""
+#   else
+#    define PRINTF_INT32_MODIFIER "l"
+#   endif
+#  endif
+# endif
+# ifndef PRINTF_INT16_MODIFIER
+#  define PRINTF_INT16_MODIFIER "h"
+# endif
+# ifndef PRINTF_INTMAX_MODIFIER
+#  define PRINTF_INTMAX_MODIFIER PRINTF_INT64_MODIFIER
+# endif
+# ifndef PRINTF_INT64_HEX_WIDTH
+#  define PRINTF_INT64_HEX_WIDTH "16"
+# endif
+# ifndef PRINTF_UINT64_HEX_WIDTH
+#  define PRINTF_UINT64_HEX_WIDTH "16"
+# endif
+# ifndef PRINTF_INT32_HEX_WIDTH
+#  define PRINTF_INT32_HEX_WIDTH "8"
+# endif
+# ifndef PRINTF_UINT32_HEX_WIDTH
+#  define PRINTF_UINT32_HEX_WIDTH "8"
+# endif
+# ifndef PRINTF_INT16_HEX_WIDTH
+#  define PRINTF_INT16_HEX_WIDTH "4"
+# endif
+# ifndef PRINTF_UINT16_HEX_WIDTH
+#  define PRINTF_UINT16_HEX_WIDTH "4"
+# endif
+# ifndef PRINTF_INT8_HEX_WIDTH
+#  define PRINTF_INT8_HEX_WIDTH "2"
+# endif
+# ifndef PRINTF_UINT8_HEX_WIDTH
+#  define PRINTF_UINT8_HEX_WIDTH "2"
+# endif
+# ifndef PRINTF_INT64_DEC_WIDTH
+#  define PRINTF_INT64_DEC_WIDTH "19"
+# endif
+# ifndef PRINTF_UINT64_DEC_WIDTH
+#  define PRINTF_UINT64_DEC_WIDTH "20"
+# endif
+# ifndef PRINTF_INT32_DEC_WIDTH
+#  define PRINTF_INT32_DEC_WIDTH "10"
+# endif
+# ifndef PRINTF_UINT32_DEC_WIDTH
+#  define PRINTF_UINT32_DEC_WIDTH "10"
+# endif
+# ifndef PRINTF_INT16_DEC_WIDTH
+#  define PRINTF_INT16_DEC_WIDTH "5"
+# endif
+# ifndef PRINTF_UINT16_DEC_WIDTH
+#  define PRINTF_UINT16_DEC_WIDTH "5"
+# endif
+# ifndef PRINTF_INT8_DEC_WIDTH
+#  define PRINTF_INT8_DEC_WIDTH "3"
+# endif
+# ifndef PRINTF_UINT8_DEC_WIDTH
+#  define PRINTF_UINT8_DEC_WIDTH "3"
+# endif
+# ifndef PRINTF_INTMAX_HEX_WIDTH
+#  define PRINTF_INTMAX_HEX_WIDTH PRINTF_UINT64_HEX_WIDTH
+# endif
+# ifndef PRINTF_UINTMAX_HEX_WIDTH
+#  define PRINTF_UINTMAX_HEX_WIDTH PRINTF_UINT64_HEX_WIDTH
+# endif
+# ifndef PRINTF_INTMAX_DEC_WIDTH
+#  define PRINTF_INTMAX_DEC_WIDTH PRINTF_UINT64_DEC_WIDTH
+# endif
+# ifndef PRINTF_UINTMAX_DEC_WIDTH
+#  define PRINTF_UINTMAX_DEC_WIDTH PRINTF_UINT64_DEC_WIDTH
+# endif
+
+/*
+ *  Something really weird is going on with Open Watcom.  Just pull some of
+ *  these duplicated definitions from Open Watcom's stdint.h file for now.
+ */
+
+# if defined (__WATCOMC__) && __WATCOMC__ >= 1250
+#  if !defined (INT64_C)
+#   define INT64_C(x)   (x + (INT64_MAX - INT64_MAX))
+#  endif
+#  if !defined (UINT64_C)
+#   define UINT64_C(x)  (x + (UINT64_MAX - UINT64_MAX))
+#  endif
+#  if !defined (INT32_C)
+#   define INT32_C(x)   (x + (INT32_MAX - INT32_MAX))
+#  endif
+#  if !defined (UINT32_C)
+#   define UINT32_C(x)  (x + (UINT32_MAX - UINT32_MAX))
+#  endif
+#  if !defined (INT16_C)
+#   define INT16_C(x)   (x)
+#  endif
+#  if !defined (UINT16_C)
+#   define UINT16_C(x)  (x)
+#  endif
+#  if !defined (INT8_C)
+#   define INT8_C(x)   (x)
+#  endif
+#  if !defined (UINT8_C)
+#   define UINT8_C(x)  (x)
+#  endif
+#  if !defined (UINT64_MAX)
+#   define UINT64_MAX  18446744073709551615ULL
+#  endif
+#  if !defined (INT64_MAX)
+#   define INT64_MAX  9223372036854775807LL
+#  endif
+#  if !defined (UINT32_MAX)
+#   define UINT32_MAX  4294967295UL
+#  endif
+#  if !defined (INT32_MAX)
+#   define INT32_MAX  2147483647L
+#  endif
+#  if !defined (INTMAX_MAX)
+#   define INTMAX_MAX INT64_MAX
+#  endif
+#  if !defined (INTMAX_MIN)
+#   define INTMAX_MIN INT64_MIN
+#  endif
+# endif
+#endif
+
+/*
+ *  I have no idea what is the truly correct thing to do on older Solaris.
+ *  From some online discussions, this seems to be what is being
+ *  recommended.  For people who actually are developing on older Solaris,
+ *  what I would like to know is, does this define all of the relevant
+ *  macros of a complete stdint.h?  Remember, in pstdint.h 64 bit is
+ *  considered optional.
+ */
+
+#if (defined(__SUNPRO_C) && __SUNPRO_C >= 0x420) && !defined(_PSTDINT_H_INCLUDED)
+#include <sys/inttypes.h>
+#define _PSTDINT_H_INCLUDED
+#endif
+
+#ifndef _PSTDINT_H_INCLUDED
+#define _PSTDINT_H_INCLUDED
+
+#ifndef SIZE_MAX
+# define SIZE_MAX ((size_t)-1)
+#endif
+
+/*
+ *  Deduce the type assignments from limits.h under the assumption that
+ *  integer sizes in bits are powers of 2, and follow the ANSI
+ *  definitions.
+ */
+
+#ifndef UINT8_MAX
+# define UINT8_MAX 0xff
+#endif
+#if !defined(uint8_t) && !defined(_UINT8_T) && !defined(vxWorks)
+# if (UCHAR_MAX == UINT8_MAX) || defined (S_SPLINT_S)
+    typedef unsigned char uint8_t;
+#   define UINT8_C(v) ((uint8_t) v)
+# else
+#   error "Platform not supported"
+# endif
+#endif
+
+#ifndef INT8_MAX
+# define INT8_MAX 0x7f
+#endif
+#ifndef INT8_MIN
+# define INT8_MIN INT8_C(0x80)
+#endif
+#if !defined(int8_t) && !defined(_INT8_T) && !defined(vxWorks)
+# if (SCHAR_MAX == INT8_MAX) || defined (S_SPLINT_S)
+    typedef signed char int8_t;
+#   define INT8_C(v) ((int8_t) v)
+# else
+#   error "Platform not supported"
+# endif
+#endif
+
+#ifndef UINT16_MAX
+# define UINT16_MAX 0xffff
+#endif
+#if !defined(uint16_t) && !defined(_UINT16_T) && !defined(vxWorks)
+#if (UINT_MAX == UINT16_MAX) || defined (S_SPLINT_S)
+  typedef unsigned int uint16_t;
+# ifndef PRINTF_INT16_MODIFIER
+#  define PRINTF_INT16_MODIFIER ""
+# endif
+# define UINT16_C(v) ((uint16_t) (v))
+#elif (USHRT_MAX == UINT16_MAX)
+  typedef unsigned short uint16_t;
+# define UINT16_C(v) ((uint16_t) (v))
+# ifndef PRINTF_INT16_MODIFIER
+#  define PRINTF_INT16_MODIFIER "h"
+# endif
+#else
+#error "Platform not supported"
+#endif
+#endif
+
+#ifndef INT16_MAX
+# define INT16_MAX 0x7fff
+#endif
+#ifndef INT16_MIN
+# define INT16_MIN INT16_C(0x8000)
+#endif
+#if !defined(int16_t) && !defined(_INT16_T) && !defined(vxWorks)
+#if (INT_MAX == INT16_MAX) || defined (S_SPLINT_S)
+  typedef signed int int16_t;
+# define INT16_C(v) ((int16_t) (v))
+# ifndef PRINTF_INT16_MODIFIER
+#  define PRINTF_INT16_MODIFIER ""
+# endif
+#elif (SHRT_MAX == INT16_MAX)
+  typedef signed short int16_t;
+# define INT16_C(v) ((int16_t) (v))
+# ifndef PRINTF_INT16_MODIFIER
+#  define PRINTF_INT16_MODIFIER "h"
+# endif
+#else
+#error "Platform not supported"
+#endif
+#endif
+
+#ifndef UINT32_MAX
+# define UINT32_MAX (0xffffffffUL)
+#endif
+#if !defined(uint32_t) && !defined(_UINT32_T) && !defined(vxWorks)
+#if (ULONG_MAX == UINT32_MAX) || defined (S_SPLINT_S)
+  typedef unsigned long uint32_t;
+# define UINT32_C(v) v ## UL
+# ifndef PRINTF_INT32_MODIFIER
+#  define PRINTF_INT32_MODIFIER "l"
+# endif
+#elif (UINT_MAX == UINT32_MAX)
+  typedef unsigned int uint32_t;
+# ifndef PRINTF_INT32_MODIFIER
+#  define PRINTF_INT32_MODIFIER ""
+# endif
+# define UINT32_C(v) v ## U
+#elif (USHRT_MAX == UINT32_MAX)
+  typedef unsigned short uint32_t;
+# define UINT32_C(v) ((unsigned short) (v))
+# ifndef PRINTF_INT32_MODIFIER
+#  define PRINTF_INT32_MODIFIER ""
+# endif
+#else
+#error "Platform not supported"
+#endif
+#endif
+
+#ifndef INT32_MAX
+# define INT32_MAX (0x7fffffffL)
+#endif
+#ifndef INT32_MIN
+# define INT32_MIN INT32_C(0x80000000)
+#endif
+#if !defined(int32_t) && !defined(_INT32_T) && !defined(vxWorks)
+#if (LONG_MAX == INT32_MAX) || defined (S_SPLINT_S)
+  typedef signed long int32_t;
+# define INT32_C(v) v ## L
+# ifndef PRINTF_INT32_MODIFIER
+#  define PRINTF_INT32_MODIFIER "l"
+# endif
+#elif (INT_MAX == INT32_MAX)
+  typedef signed int int32_t;
+# define INT32_C(v) v
+# ifndef PRINTF_INT32_MODIFIER
+#  define PRINTF_INT32_MODIFIER ""
+# endif
+#elif (SHRT_MAX == INT32_MAX)
+  typedef signed short int32_t;
+# define INT32_C(v) ((short) (v))
+# ifndef PRINTF_INT32_MODIFIER
+#  define PRINTF_INT32_MODIFIER ""
+# endif
+#else
+#error "Platform not supported"
+#endif
+#endif
+
+/*
+ *  The macro stdint_int64_defined is temporarily used to record
+ *  whether or not 64 integer support is available.  It must be
+ *  defined for any 64 integer extensions for new platforms that are
+ *  added.
+ */
+
+#undef stdint_int64_defined
+#if (defined(__STDC__) && defined(__STDC_VERSION__)) || defined (S_SPLINT_S)
+# if (__STDC__ && __STDC_VERSION__ >= 199901L) || defined (S_SPLINT_S)
+#  define stdint_int64_defined
+   typedef long long int64_t;
+   typedef unsigned long long uint64_t;
+#  define UINT64_C(v) v ## ULL
+#  define  INT64_C(v) v ## LL
+#  ifndef PRINTF_INT64_MODIFIER
+#   define PRINTF_INT64_MODIFIER "ll"
+#  endif
+# endif
+#endif
+
+#if !defined (stdint_int64_defined)
+# if defined(__GNUC__) && !defined(vxWorks)
+#  define stdint_int64_defined
+   __extension__ typedef long long int64_t;
+   __extension__ typedef unsigned long long uint64_t;
+#  define UINT64_C(v) v ## ULL
+#  define  INT64_C(v) v ## LL
+#  ifndef PRINTF_INT64_MODIFIER
+#   define PRINTF_INT64_MODIFIER "ll"
+#  endif
+# elif defined(__MWERKS__) || defined (__SUNPRO_C) || defined (__SUNPRO_CC) || defined (__APPLE_CC__) || defined (_LONG_LONG) || defined (_CRAYC) || defined (S_SPLINT_S)
+#  define stdint_int64_defined
+   typedef long long int64_t;
+   typedef unsigned long long uint64_t;
+#  define UINT64_C(v) v ## ULL
+#  define  INT64_C(v) v ## LL
+#  ifndef PRINTF_INT64_MODIFIER
+#   define PRINTF_INT64_MODIFIER "ll"
+#  endif
+# elif (defined(__WATCOMC__) && defined(__WATCOM_INT64__)) || (defined(_MSC_VER) && _INTEGRAL_MAX_BITS >= 64) || (defined (__BORLANDC__) && __BORLANDC__ > 0x460) || defined (__alpha) || defined (__DECC)
+#  define stdint_int64_defined
+   typedef __int64 int64_t;
+   typedef unsigned __int64 uint64_t;
+#  define UINT64_C(v) v ## UI64
+#  define  INT64_C(v) v ## I64
+#  ifndef PRINTF_INT64_MODIFIER
+#   define PRINTF_INT64_MODIFIER "I64"
+#  endif
+# endif
+#endif
+
+#if !defined (LONG_LONG_MAX) && defined (INT64_C)
+# define LONG_LONG_MAX INT64_C (9223372036854775807)
+#endif
+#ifndef ULONG_LONG_MAX
+# define ULONG_LONG_MAX UINT64_C (18446744073709551615)
+#endif
+
+#if !defined (INT64_MAX) && defined (INT64_C)
+# define INT64_MAX INT64_C (9223372036854775807)
+#endif
+#if !defined (INT64_MIN) && defined (INT64_C)
+# define INT64_MIN INT64_C (-9223372036854775808)
+#endif
+#if !defined (UINT64_MAX) && defined (INT64_C)
+# define UINT64_MAX UINT64_C (18446744073709551615)
+#endif
+
+/*
+ *  Width of hexadecimal for number field.
+ */
+
+#ifndef PRINTF_INT64_HEX_WIDTH
+# define PRINTF_INT64_HEX_WIDTH "16"
+#endif
+#ifndef PRINTF_INT32_HEX_WIDTH
+# define PRINTF_INT32_HEX_WIDTH "8"
+#endif
+#ifndef PRINTF_INT16_HEX_WIDTH
+# define PRINTF_INT16_HEX_WIDTH "4"
+#endif
+#ifndef PRINTF_INT8_HEX_WIDTH
+# define PRINTF_INT8_HEX_WIDTH "2"
+#endif
+#ifndef PRINTF_INT64_DEC_WIDTH
+# define PRINTF_INT64_DEC_WIDTH "19"
+#endif
+#ifndef PRINTF_INT32_DEC_WIDTH
+# define PRINTF_INT32_DEC_WIDTH "10"
+#endif
+#ifndef PRINTF_INT16_DEC_WIDTH
+# define PRINTF_INT16_DEC_WIDTH "5"
+#endif
+#ifndef PRINTF_INT8_DEC_WIDTH
+# define PRINTF_INT8_DEC_WIDTH "3"
+#endif
+#ifndef PRINTF_UINT64_DEC_WIDTH
+# define PRINTF_UINT64_DEC_WIDTH "20"
+#endif
+#ifndef PRINTF_UINT32_DEC_WIDTH
+# define PRINTF_UINT32_DEC_WIDTH "10"
+#endif
+#ifndef PRINTF_UINT16_DEC_WIDTH
+# define PRINTF_UINT16_DEC_WIDTH "5"
+#endif
+#ifndef PRINTF_UINT8_DEC_WIDTH
+# define PRINTF_UINT8_DEC_WIDTH "3"
+#endif
+
+/*
+ *  Ok, lets not worry about 128 bit integers for now.  Moore's law says
+ *  we don't need to worry about that until about 2040 at which point
+ *  we'll have bigger things to worry about.
+ */
+
+#ifdef stdint_int64_defined
+  typedef int64_t intmax_t;
+  typedef uint64_t uintmax_t;
+# define  INTMAX_MAX   INT64_MAX
+# define  INTMAX_MIN   INT64_MIN
+# define UINTMAX_MAX  UINT64_MAX
+# define UINTMAX_C(v) UINT64_C(v)
+# define  INTMAX_C(v)  INT64_C(v)
+# ifndef PRINTF_INTMAX_MODIFIER
+#   define PRINTF_INTMAX_MODIFIER PRINTF_INT64_MODIFIER
+# endif
+# ifndef PRINTF_INTMAX_HEX_WIDTH
+#  define PRINTF_INTMAX_HEX_WIDTH PRINTF_INT64_HEX_WIDTH
+# endif
+# ifndef PRINTF_INTMAX_DEC_WIDTH
+#  define PRINTF_INTMAX_DEC_WIDTH PRINTF_INT64_DEC_WIDTH
+# endif
+#else
+  typedef int32_t intmax_t;
+  typedef uint32_t uintmax_t;
+# define  INTMAX_MAX   INT32_MAX
+# define UINTMAX_MAX  UINT32_MAX
+# define UINTMAX_C(v) UINT32_C(v)
+# define  INTMAX_C(v)  INT32_C(v)
+# ifndef PRINTF_INTMAX_MODIFIER
+#   define PRINTF_INTMAX_MODIFIER PRINTF_INT32_MODIFIER
+# endif
+# ifndef PRINTF_INTMAX_HEX_WIDTH
+#  define PRINTF_INTMAX_HEX_WIDTH PRINTF_INT32_HEX_WIDTH
+# endif
+# ifndef PRINTF_INTMAX_DEC_WIDTH
+#  define PRINTF_INTMAX_DEC_WIDTH PRINTF_INT32_DEC_WIDTH
+# endif
+#endif
+
+/*
+ *  Because this file currently only supports platforms which have
+ *  precise powers of 2 as bit sizes for the default integers, the
+ *  least definitions are all trivial.  Its possible that a future
+ *  version of this file could have different definitions.
+ */
+
+#ifndef stdint_least_defined
+  typedef   int8_t   int_least8_t;
+  typedef  uint8_t  uint_least8_t;
+  typedef  int16_t  int_least16_t;
+  typedef uint16_t uint_least16_t;
+  typedef  int32_t  int_least32_t;
+  typedef uint32_t uint_least32_t;
+# define PRINTF_LEAST32_MODIFIER PRINTF_INT32_MODIFIER
+# define PRINTF_LEAST16_MODIFIER PRINTF_INT16_MODIFIER
+# define  UINT_LEAST8_MAX  UINT8_MAX
+# define   INT_LEAST8_MAX   INT8_MAX
+# define UINT_LEAST16_MAX UINT16_MAX
+# define  INT_LEAST16_MAX  INT16_MAX
+# define UINT_LEAST32_MAX UINT32_MAX
+# define  INT_LEAST32_MAX  INT32_MAX
+# define   INT_LEAST8_MIN   INT8_MIN
+# define  INT_LEAST16_MIN  INT16_MIN
+# define  INT_LEAST32_MIN  INT32_MIN
+# ifdef stdint_int64_defined
+    typedef  int64_t  int_least64_t;
+    typedef uint64_t uint_least64_t;
+#   define PRINTF_LEAST64_MODIFIER PRINTF_INT64_MODIFIER
+#   define UINT_LEAST64_MAX UINT64_MAX
+#   define  INT_LEAST64_MAX  INT64_MAX
+#   define  INT_LEAST64_MIN  INT64_MIN
+# endif
+#endif
+#undef stdint_least_defined
+
+/*
+ *  The ANSI C committee has defined *int*_fast*_t types as well.  This,
+ *  of course, defies rationality -- you can't know what will be fast
+ *  just from the type itself.  Even for a given architecture, compatible
+ *  implementations might have different performance characteristics.
+ *  Developers are warned to stay away from these types when using this
+ *  or any other stdint.h.
+ */
+
+typedef   int_least8_t   int_fast8_t;
+typedef  uint_least8_t  uint_fast8_t;
+typedef  int_least16_t  int_fast16_t;
+typedef uint_least16_t uint_fast16_t;
+typedef  int_least32_t  int_fast32_t;
+typedef uint_least32_t uint_fast32_t;
+#define  UINT_FAST8_MAX  UINT_LEAST8_MAX
+#define   INT_FAST8_MAX   INT_LEAST8_MAX
+#define UINT_FAST16_MAX UINT_LEAST16_MAX
+#define  INT_FAST16_MAX  INT_LEAST16_MAX
+#define UINT_FAST32_MAX UINT_LEAST32_MAX
+#define  INT_FAST32_MAX  INT_LEAST32_MAX
+#define   INT_FAST8_MIN   INT_LEAST8_MIN
+#define  INT_FAST16_MIN  INT_LEAST16_MIN
+#define  INT_FAST32_MIN  INT_LEAST32_MIN
+#ifdef stdint_int64_defined
+  typedef  int_least64_t  int_fast64_t;
+  typedef uint_least64_t uint_fast64_t;
+# define UINT_FAST64_MAX UINT_LEAST64_MAX
+# define  INT_FAST64_MAX  INT_LEAST64_MAX
+# define  INT_FAST64_MIN  INT_LEAST64_MIN
+#endif
+
+#undef stdint_int64_defined
+
+/*
+ *  Whatever piecemeal, per compiler thing we can do about the wchar_t
+ *  type limits.
+ */
+
+#if defined(__WATCOMC__) || defined(_MSC_VER) || defined (__GNUC__) && !defined(vxWorks)
+# include <wchar.h>
+# ifndef WCHAR_MIN
+#  define WCHAR_MIN 0
+# endif
+# ifndef WCHAR_MAX
+#  define WCHAR_MAX ((wchar_t)-1)
+# endif
+#endif
+
+/*
+ *  Whatever piecemeal, per compiler/platform thing we can do about the
+ *  (u)intptr_t types and limits.
+ */
+
+#if (defined (_MSC_VER) && defined (_UINTPTR_T_DEFINED)) || defined (_UINTPTR_T)
+# define STDINT_H_UINTPTR_T_DEFINED
+#endif
+
+#ifndef STDINT_H_UINTPTR_T_DEFINED
+# if defined (__alpha__) || defined (__ia64__) || defined (__x86_64__) || defined (_WIN64) || defined (__ppc64__)
+#  define stdint_intptr_bits 64
+# elif defined (__WATCOMC__) || defined (__TURBOC__)
+#  if defined(__TINY__) || defined(__SMALL__) || defined(__MEDIUM__)
+#    define stdint_intptr_bits 16
+#  else
+#    define stdint_intptr_bits 32
+#  endif
+# elif defined (__i386__) || defined (_WIN32) || defined (WIN32) || defined (__ppc64__)
+#  define stdint_intptr_bits 32
+# elif defined (__INTEL_COMPILER)
+/* TODO -- what did Intel do about x86-64? */
+# else
+/* #error "This platform might not be supported yet" */
+# endif
+
+# ifdef stdint_intptr_bits
+#  define stdint_intptr_glue3_i(a,b,c)  a##b##c
+#  define stdint_intptr_glue3(a,b,c)    stdint_intptr_glue3_i(a,b,c)
+#  ifndef PRINTF_INTPTR_MODIFIER
+#    define PRINTF_INTPTR_MODIFIER      stdint_intptr_glue3(PRINTF_INT,stdint_intptr_bits,_MODIFIER)
+#  endif
+#  ifndef PTRDIFF_MAX
+#    define PTRDIFF_MAX                 stdint_intptr_glue3(INT,stdint_intptr_bits,_MAX)
+#  endif
+#  ifndef PTRDIFF_MIN
+#    define PTRDIFF_MIN                 stdint_intptr_glue3(INT,stdint_intptr_bits,_MIN)
+#  endif
+#  ifndef UINTPTR_MAX
+#    define UINTPTR_MAX                 stdint_intptr_glue3(UINT,stdint_intptr_bits,_MAX)
+#  endif
+#  ifndef INTPTR_MAX
+#    define INTPTR_MAX                  stdint_intptr_glue3(INT,stdint_intptr_bits,_MAX)
+#  endif
+#  ifndef INTPTR_MIN
+#    define INTPTR_MIN                  stdint_intptr_glue3(INT,stdint_intptr_bits,_MIN)
+#  endif
+#  ifndef INTPTR_C
+#    define INTPTR_C(x)                 stdint_intptr_glue3(INT,stdint_intptr_bits,_C)(x)
+#  endif
+#  ifndef UINTPTR_C
+#    define UINTPTR_C(x)                stdint_intptr_glue3(UINT,stdint_intptr_bits,_C)(x)
+#  endif
+  typedef stdint_intptr_glue3(uint,stdint_intptr_bits,_t) uintptr_t;
+  typedef stdint_intptr_glue3( int,stdint_intptr_bits,_t)  intptr_t;
+# else
+/* TODO -- This following is likely wrong for some platforms, and does
+   nothing for the definition of uintptr_t. */
+  typedef ptrdiff_t intptr_t;
+# endif
+# define STDINT_H_UINTPTR_T_DEFINED
+#endif
+
+/*
+ *  Assumes sig_atomic_t is signed and we have a 2s complement machine.
+ */
+
+#ifndef SIG_ATOMIC_MAX
+# define SIG_ATOMIC_MAX ((((sig_atomic_t) 1) << (sizeof (sig_atomic_t)*CHAR_BIT-1)) - 1)
+#endif
+
+#endif
+
+#if defined (__TEST_PSTDINT_FOR_CORRECTNESS)
+
+/*
+ *  Please compile with the maximum warning settings to make sure macros are
+ *  not defined more than once.
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#define glue3_aux(x,y,z) x ## y ## z
+#define glue3(x,y,z) glue3_aux(x,y,z)
+
+#define DECLU(bits) glue3(uint,bits,_t) glue3(u,bits,) = glue3(UINT,bits,_C) (0);
+#define DECLI(bits) glue3(int,bits,_t) glue3(i,bits,) = glue3(INT,bits,_C) (0);
+
+#define DECL(us,bits) glue3(DECL,us,) (bits)
+
+#define TESTUMAX(bits) glue3(u,bits,) = ~glue3(u,bits,); if (glue3(UINT,bits,_MAX) != glue3(u,bits,)) printf ("Something wrong with UINT%d_MAX\n", bits)
+
+#define REPORTERROR(msg) { err_n++; if (err_first <= 0) err_first = __LINE__; printf msg; }
+
+#define X_SIZE_MAX ((size_t)-1)
+
+int main () {
+	int err_n = 0;
+	int err_first = 0;
+	DECL(I,8)
+	DECL(U,8)
+	DECL(I,16)
+	DECL(U,16)
+	DECL(I,32)
+	DECL(U,32)
+#ifdef INT64_MAX
+	DECL(I,64)
+	DECL(U,64)
+#endif
+	intmax_t imax = INTMAX_C(0);
+	uintmax_t umax = UINTMAX_C(0);
+	char str0[256], str1[256];
+
+	sprintf (str0, "%" PRINTF_INT32_MODIFIER "d", INT32_C(2147483647));
+	if (0 != strcmp (str0, "2147483647")) REPORTERROR (("Something wrong with PRINTF_INT32_MODIFIER : %s\n", str0));
+	if (atoi(PRINTF_INT32_DEC_WIDTH) != (int) strlen(str0)) REPORTERROR (("Something wrong with PRINTF_INT32_DEC_WIDTH : %s\n", PRINTF_INT32_DEC_WIDTH));
+	sprintf (str0, "%" PRINTF_INT32_MODIFIER "u", UINT32_C(4294967295));
+	if (0 != strcmp (str0, "4294967295")) REPORTERROR (("Something wrong with PRINTF_INT32_MODIFIER : %s\n", str0));
+	if (atoi(PRINTF_UINT32_DEC_WIDTH) != (int) strlen(str0)) REPORTERROR (("Something wrong with PRINTF_UINT32_DEC_WIDTH : %s\n", PRINTF_UINT32_DEC_WIDTH));
+#ifdef INT64_MAX
+	sprintf (str1, "%" PRINTF_INT64_MODIFIER "d", INT64_C(9223372036854775807));
+	if (0 != strcmp (str1, "9223372036854775807")) REPORTERROR (("Something wrong with PRINTF_INT32_MODIFIER : %s\n", str1));
+	if (atoi(PRINTF_INT64_DEC_WIDTH) != (int) strlen(str1)) REPORTERROR (("Something wrong with PRINTF_INT64_DEC_WIDTH : %s, %d\n", PRINTF_INT64_DEC_WIDTH, (int) strlen(str1)));
+	sprintf (str1, "%" PRINTF_INT64_MODIFIER "u", UINT64_C(18446744073709550591));
+	if (0 != strcmp (str1, "18446744073709550591")) REPORTERROR (("Something wrong with PRINTF_INT32_MODIFIER : %s\n", str1));
+	if (atoi(PRINTF_UINT64_DEC_WIDTH) != (int) strlen(str1)) REPORTERROR (("Something wrong with PRINTF_UINT64_DEC_WIDTH : %s, %d\n", PRINTF_UINT64_DEC_WIDTH, (int) strlen(str1)));
+#endif
+
+	sprintf (str0, "%d %x\n", 0, ~0);
+
+	sprintf (str1, "%d %x\n",  i8, ~0);
+	if (0 != strcmp (str0, str1)) REPORTERROR (("Something wrong with i8 : %s\n", str1));
+	sprintf (str1, "%u %x\n",  u8, ~0);
+	if (0 != strcmp (str0, str1)) REPORTERROR (("Something wrong with u8 : %s\n", str1));
+	sprintf (str1, "%d %x\n",  i16, ~0);
+	if (0 != strcmp (str0, str1)) REPORTERROR (("Something wrong with i16 : %s\n", str1));
+	sprintf (str1, "%u %x\n",  u16, ~0);
+	if (0 != strcmp (str0, str1)) REPORTERROR (("Something wrong with u16 : %s\n", str1));
+	sprintf (str1, "%" PRINTF_INT32_MODIFIER "d %x\n",  i32, ~0);
+	if (0 != strcmp (str0, str1)) REPORTERROR (("Something wrong with i32 : %s\n", str1));
+	sprintf (str1, "%" PRINTF_INT32_MODIFIER "u %x\n",  u32, ~0);
+	if (0 != strcmp (str0, str1)) REPORTERROR (("Something wrong with u32 : %s\n", str1));
+#ifdef INT64_MAX
+	sprintf (str1, "%" PRINTF_INT64_MODIFIER "d %x\n",  i64, ~0);
+	if (0 != strcmp (str0, str1)) REPORTERROR (("Something wrong with i64 : %s\n", str1));
+#endif
+	sprintf (str1, "%" PRINTF_INTMAX_MODIFIER "d %x\n",  imax, ~0);
+	if (0 != strcmp (str0, str1)) REPORTERROR (("Something wrong with imax : %s\n", str1));
+	sprintf (str1, "%" PRINTF_INTMAX_MODIFIER "u %x\n",  umax, ~0);
+	if (0 != strcmp (str0, str1)) REPORTERROR (("Something wrong with umax : %s\n", str1));
+
+	TESTUMAX(8);
+	TESTUMAX(16);
+	TESTUMAX(32);
+#ifdef INT64_MAX
+	TESTUMAX(64);
+#endif
+
+#define STR(v) #v
+#define Q(v) printf ("sizeof " STR(v) " = %u\n", (unsigned) sizeof (v));
+	if (err_n) {
+		printf ("pstdint.h is not correct.  Please use sizes below to correct it:\n");
+	}
+
+	Q(int)
+	Q(unsigned)
+	Q(long int)
+	Q(short int)
+	Q(int8_t)
+	Q(int16_t)
+	Q(int32_t)
+#ifdef INT64_MAX
+	Q(int64_t)
+#endif
+
+#if UINT_MAX < X_SIZE_MAX
+	printf ("UINT_MAX < X_SIZE_MAX\n");
+#else
+	printf ("UINT_MAX >= X_SIZE_MAX\n");
+#endif
+	printf ("%" PRINTF_INT64_MODIFIER "u vs %" PRINTF_INT64_MODIFIER "u\n", UINT_MAX, X_SIZE_MAX);
+
+	return EXIT_SUCCESS;
+}
+
+#endif

--- a/meson.build
+++ b/meson.build
@@ -25,6 +25,7 @@ subdir('src')
 dep_names = [
   'ntk',
   'cairo',
+  'openav_ctlra',
   'liblo',
   'jack',
   'sndfile',
@@ -39,4 +40,5 @@ endforeach
 
 # compile the main project
 executable('luppp', luppp_src + [version_hxx],
+    link_args : ['-ltcc', '-ldl'],
     dependencies: deps)

--- a/src/controller/controller.hxx
+++ b/src/controller/controller.hxx
@@ -50,6 +50,8 @@ public:
 		return 0;
 	}
 
+	virtual void poll() {}
+
 	virtual ~Controller() {};
 
 	/// get the status of the controller

--- a/src/controller/ctlra.cxx
+++ b/src/controller/ctlra.cxx
@@ -315,10 +315,12 @@ accept_dev_func(const struct ctlra_dev_info_t *info,
 
 CtlraScript::CtlraScript(std::string file) :
 	Controller(),
-	MidiIO()
+	MidiIO(),
+	program(0)
 {
 	/* Step 1: compile script */
 	this->filename = file;
+	LUPPP_NOTE("CtlraScript() got file %s", file.c_str());
 
 	int err = compile();
 	if(err) {

--- a/src/controller/ctlra.cxx
+++ b/src/controller/ctlra.cxx
@@ -274,14 +274,13 @@ luppp_event_func(struct ctlra_dev_t* dev, uint32_t num_events,
 	c->ctlra_forward(dev, num_events, events);
 }
 
-void CtlraScript::poll_devices()
+void CtlraScript::poll()
 {
 	if(!dev) {
 		printf("%s error, no dev!\n", __func__);
 		return;
 	}
 
-	//ctlra_rt_safe_idle_iter(dev);
 	ctlra_idle_iter(dev);
 }
 

--- a/src/controller/ctlra.cxx
+++ b/src/controller/ctlra.cxx
@@ -1,0 +1,431 @@
+/*
+ * Author: Harry van Haaren 2018
+ *         harryhaaren@gmail.com
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "ctlra.hxx"
+
+#include <errno.h>
+#include <iostream>
+#include <sys/stat.h>
+
+#include "../jack.hxx"
+#include "../event.hxx"
+#include "../logic.hxx"
+#include "../gridlogic.hxx"
+#include "../timemanager.hxx"
+
+#include "../eventhandler.hxx"
+#include "luppp_script_api.h"
+
+#include "libtcc.h"
+
+extern Jack* jack;
+
+static void error_func(void *opaque, const char *msg)
+{
+	printf("TCC ERROR: %s\n", msg);
+}
+
+static void error(const char *msg)
+{
+	printf("%s\n", msg);
+}
+
+void luppp_write_ctlra_light(void *ctlra, int light, int light_status)
+{
+	((CtlraScript*)ctlra)->writeCtlraLight(light, light_status);
+}
+
+void CtlraScript::writeCtlraLight(int light, int status)
+{
+	struct ctlra_dev_t *hack_dev = (struct ctlra_dev_t *)hack_current_dev;
+	ctlra_dev_light_set(hack_dev, light, status);
+	//ctlra_dev_light_flush(hack_dev, 0);
+}
+
+void luppp_do(enum EVENT_ID id, void* e)
+{
+	switch(id) {
+	case EVENT_TRACK_SEND_ACTIVE: {
+		struct event_track_send_active *ev =
+			(struct event_track_send_active *)e;
+		jack->getLogic()->trackSendActive(ev->track, ev->send,
+						  ev->active);
+		break;
+		}
+	case EVENT_TRACK_SEND: {
+		struct event_track_send *ev =
+			(struct event_track_send *)e;
+		jack->getLogic()->trackSend(ev->track, ev->send,
+						  ev->value);
+		break;
+		}
+	case EVENT_TRACK_VOLUME: {
+		struct event_track_volume *ev = (struct event_track_volume *)e;
+		jack->getLogic()->trackVolume(ev->track, ev->value);
+		break;
+		}
+	case EVENT_TRACK_RECORD_ARM: {
+		struct event_track_record_arm *ev =
+			(struct event_track_record_arm *)e;
+		jack->getLogic()->trackRecordArm(ev->track, ev->armed);
+		break;
+		}
+	case EVENT_TRACK_JACKSEND: {
+		struct event_track_jack_send *ev =
+			(struct event_track_jack_send *)e;
+		jack->getLogic()->trackJackSend(ev->track, ev->value);
+		break;
+		}
+	case EVENT_TRACK_JACKSEND_ACTIVE: {
+		struct event_track_jack_send_active *ev =
+			(struct event_track_jack_send_active *)e;
+		jack->getLogic()->trackJackSendActivate(ev->track, ev->active);
+		break;
+		}
+	case EVENT_GRID_PRESS_RELEASE: {
+		struct event_grid_press_release *ev =
+			(struct event_grid_press_release *)e;
+		/* TODO: Refactor to GridLogic::press_release(int pressed);*/
+		if(ev->pressed)
+			jack->getGridLogic()->pressed(ev->track, ev->scene);
+		else
+			jack->getGridLogic()->released(ev->track, ev->scene);
+		break;
+		}
+	case EVENT_GRID_LAUNCH_SCENE: {
+		struct event_grid_launch_scene *ev =
+			(struct event_grid_launch_scene *)e;
+		jack->getGridLogic()->launchScene(ev->scene);
+		break;
+		}
+	case EVENT_TEMPO_BPM: {
+		struct event_tempo_bpm *ev = (struct event_tempo_bpm *)e;
+		jack->getTimeManager()->setBpm(ev->bpm);
+		break;
+		}
+	case EVENT_TEMPO_TAP: {
+		struct event_tempo_tap *ev = (struct event_tempo_tap *)e;
+		/* No params, this counts *when* the event arrives, not
+		 * what it contains. A boolean integer indicates pressed
+		 * or released state of the button for LEDs */
+		jack->getTimeManager()->tap();
+		break;
+		}
+	case EVENT_MASTER_VOLUME: {
+		struct event_master_volume *ev = (struct event_master_volume *)e;
+		jack->masterVolume(ev->volume);
+		break;
+		}
+	case EVENT_MASTER_RETURN: {
+		struct event_master_return*ev = (struct event_master_return *)e;
+		jack->returnVolume(ev->volume);
+		break;
+		}
+	default: break;
+	}
+}
+
+static int file_modify_time(const char *path, time_t *new_time)
+{
+	if(new_time == 0)
+		return -1;
+
+	struct stat file_stat;
+	int err = stat(path, &file_stat);
+	if (err != 0) {
+		return -2;
+	}
+	*new_time = file_stat.st_mtime;
+	return 0;
+}
+
+const char *CtlraScript::getCtlraName(int ctlr_type, int ctlr_id)
+{
+	struct ctlra_dev_t * d = (struct ctlra_dev_t *)hack_current_dev;
+	struct ctlra_dev_info_t dev_info;
+	ctlra_dev_get_info(d, &dev_info);
+
+	const int c = 5 ;//dev_info.control_count[CTLRA_EVENT_SLIDER];
+	/*
+	for(int i = 0; i < c; i++) {
+		const char *n = ctlra_info_get_name(&dev_info,
+						    (enum ctlra_event_type_t)ctlr_type, ctlr_id);
+		printf("%s\n", n);
+	}
+	*/
+	return 0;
+}
+
+int CtlraScript::compile()
+{
+	if(program) {
+		free(program);
+	}
+	program_ok = 0;
+
+	TCCState *s;
+	s = tcc_new();
+	if(!s)
+		error("failed to create tcc context\n");
+
+	tcc_set_error_func(s, 0x0, error_func);
+	tcc_set_options(s, "-g");
+	tcc_set_output_type(s, TCC_OUTPUT_MEMORY);
+
+	int ret = tcc_add_file(s, filename.c_str());
+	if(ret < 0) {
+		printf("gracefully handling error now... \n");
+		return -EINVAL;
+	}
+
+	tcc_add_symbol(s, "luppp_do", (void *)luppp_do);
+	if(ret < 0) {
+		error("failed to insert luppp_do() symbol\n");
+		return -EINVAL;
+	}
+
+	tcc_add_symbol(s, "luppp_write_ctlra_light",
+		       (void *)luppp_write_ctlra_light);
+	if(ret < 0) {
+		error("failed to insert luppp_write_ctlra_light() symbol\n");
+		return -EINVAL;
+	}
+
+	program = malloc(tcc_relocate(s, NULL));
+	if(!program)
+		error("failed to alloc mem for program\n");
+	ret = tcc_relocate(s, program);
+	if(ret < 0) {
+		error("failed to relocate code to program memory\n");
+		return -EINVAL;
+	}
+
+	tcc_event_func = (tcc_event_func_t)tcc_get_symbol(s, "test_ctlra");
+	if(!tcc_event_func) {
+		error("failed to get tcc_event_func\n");
+	}
+
+	/* handles events from Luppp */
+	handle = (ctlra_handle_event)tcc_get_symbol(s, "test_handle");
+	if(!handle)
+		error("failed to get test handle\n");
+
+	tcc_delete(s);
+
+	/* Store the time of compiling */
+	file_modify_time(filename.c_str(), &script_load_time);
+	program_ok = 1;
+	printf("compiled ok\n");
+
+	//getCtlraName(0, 0);
+
+	return 0;
+}
+
+void CtlraScript::script_reload()
+{
+	time_t new_time;
+	int err = file_modify_time(filename.c_str(), &new_time);
+	if(err)
+		return;
+
+	if(new_time > script_load_time) {
+		printf("CtlraScript %d : Reloading script \"%s\"\n",
+		       getID(), filename.c_str());
+		compile();
+	}
+}
+
+
+/* Non static version of the same - needed to access the tcc functions */
+void CtlraScript::ctlra_forward(struct ctlra_dev_t* dev, uint32_t num_events,
+		   struct ctlra_event_t** events)
+{
+	hack_current_dev = dev;
+	script_reload();
+	printf("here\n");
+	if(tcc_event_func) {
+		tcc_event_func(num_events, events);
+	}
+	//ctlra_dev_light_flush((struct ctlra_dev_t *)hack_current_dev, 0);
+}
+
+static void
+luppp_event_func(struct ctlra_dev_t* dev, uint32_t num_events,
+		 struct ctlra_event_t** events, void *userdata)
+{
+	printf("luppp event func\n");
+	CtlraScript* c = (CtlraScript*)userdata;
+	c->ctlra_forward(dev, num_events, events);
+}
+
+void CtlraScript::poll_devices()
+{
+	if(!dev) {
+		printf("%s error, no dev!\n", __func__);
+		return;
+	}
+
+	//ctlra_rt_safe_idle_iter(dev);
+	ctlra_idle_iter(dev);
+}
+
+static int
+accept_dev_func(const struct ctlra_dev_info_t *info,
+                    ctlra_event_func *event_func,
+                    ctlra_feedback_func *feedback_func,
+                    ctlra_remove_dev_func *remove_func,
+                    void **userdata_for_event_func,
+                    void *userdata)
+{
+	printf("LupppCtlra: accepting %s %s\n", info->vendor, info->device);
+	/* Fill in the callbacks the device needs to function.
+	 * In this example, all events are routed to the above functions,
+	 * which simply print the event that occurred. Look at the daemon/
+	 * example in order to see how to send MIDI messages for events */
+	*event_func    = luppp_event_func;
+
+	/* TODO: Feedback */
+#if 0
+	//*feedback_func = luppp_feedback_func;
+	//*remove_func   = luppp_remove_func;
+#endif
+	/* Optionally provide a userdata. It is passed to the callback
+	 * functions simple_event_func() and simple_feedback_func(). */
+	*userdata_for_event_func = userdata;
+
+	return 1;
+}
+
+
+CtlraScript::CtlraScript(std::string file) :
+	Controller(),
+	MidiIO()
+{
+	/* Step 1: compile script */
+	this->filename = file;
+
+	int err = compile();
+	if(err) {
+		printf("compile failed\n");
+		return;
+	}
+
+	struct ctlra_create_opts_t opts = {0};
+	//opts.flags_rt_safe = 0;
+	dev = ctlra_create(&opts);
+	if(!dev) {
+		printf("Warning, failed to create ctlra instance!!\n");
+		return;
+	}
+
+	// TODO: rework accept dev to new signature
+	//int num_devs = ctlra_probe(dev, accept_dev_func, this);
+
+	stat = CONTROLLER_OK;
+}
+
+CtlraScript::~CtlraScript()
+{
+	if(program)
+		free(program);
+	ctlra_exit(dev);
+}
+
+int CtlraScript::registerComponents()
+{
+	// makes JACK add this controller to the midiObservers list:
+	// note the static_cast<>() is *needed* here for multiple-inheritance
+	MidiIO* m = static_cast<MidiIO*>(this);
+
+	printf("registering ports!!\n");
+	registerMidiPorts( "testScripted" );
+
+	jack->registerMidiIO( m );
+
+	return LUPPP_RETURN_OK;
+}
+
+
+Controller::STATUS CtlraScript::status()
+{
+	return stat;
+}
+
+void CtlraScript::midi(unsigned char* midi)
+{
+	script_reload();
+
+	if(!program_ok)
+		return;
+
+	int status  = midi[0];
+	int data    = midi[1];
+	float value = midi[2] / 127.f;
+
+	//printf("%s : got %2x %2x %0.2f\n", __func__, status, data, value);
+	//int ret = poll(midi);
+}
+
+struct event_trac_send_active_t {
+	int type;
+	int track;
+	int send;
+	int active;
+};
+
+void CtlraScript::trackSendActive(int t, int send, bool a)
+{
+	if(!program_ok)
+		return;
+
+	struct event_track_send_active ev = {
+		.track = t,
+		.send = send,
+		.active = 0,
+	};
+	if(a)
+		ev.active = 1;
+	handle(this, EVENT_TRACK_SEND_ACTIVE, &ev);
+	ctlra_dev_light_flush((struct ctlra_dev_t *)hack_current_dev, 0);
+}
+
+void CtlraScript::barBeat(int bar, int beat)
+{
+	if(!program_ok)
+		return;
+
+	struct event_time_bar_beat ev = {
+		.bar = bar,
+		.beat = beat,
+	};
+	handle(this, EVENT_TIME_BAR_BEAT, &ev);
+	ctlra_dev_light_flush((struct ctlra_dev_t *)hack_current_dev, 0);
+}
+
+void CtlraScript::setSceneState(int track, int scene, GridLogic::State s)
+{
+	struct event_grid_press_release ev = {
+		.track = track,
+		.scene = scene,
+		.pressed = (int)s,
+	};
+	handle(this, EVENT_GRID_PRESS_RELEASE, &ev);
+	ctlra_dev_light_flush((struct ctlra_dev_t *)hack_current_dev, 0);
+}
+

--- a/src/controller/ctlra.cxx
+++ b/src/controller/ctlra.cxx
@@ -286,32 +286,21 @@ void CtlraScript::poll_devices()
 }
 
 static int
-accept_dev_func(const struct ctlra_dev_info_t *info,
-                    ctlra_event_func *event_func,
-                    ctlra_feedback_func *feedback_func,
-                    ctlra_remove_dev_func *remove_func,
-                    void **userdata_for_event_func,
-                    void *userdata)
+accept_dev_func(struct ctlra_t *ctlra,
+		const struct ctlra_dev_info_t *info,
+		struct ctlra_dev_t *dev,
+		void *userdata)
 {
 	printf("LupppCtlra: accepting %s %s\n", info->vendor, info->device);
-	/* Fill in the callbacks the device needs to function.
-	 * In this example, all events are routed to the above functions,
-	 * which simply print the event that occurred. Look at the daemon/
-	 * example in order to see how to send MIDI messages for events */
-	*event_func    = luppp_event_func;
-
-	/* TODO: Feedback */
-#if 0
-	//*feedback_func = luppp_feedback_func;
-	//*remove_func   = luppp_remove_func;
-#endif
-	/* Optionally provide a userdata. It is passed to the callback
-	 * functions simple_event_func() and simple_feedback_func(). */
-	*userdata_for_event_func = userdata;
-
+	ctlra_dev_set_event_func(dev, luppp_event_func);
+	/*
+	ctlra_dev_set_feedback_func(dev, luppp_feedback_func);
+	ctlra_dev_set_screen_feedback_func(dev, luppp_screen_redraw_func);
+	ctlra_dev_set_remove_func(dev, luppp_remove_func);
+	*/
+	ctlra_dev_set_callback_userdata(dev, userdata);
 	return 1;
 }
-
 
 CtlraScript::CtlraScript(std::string file) :
 	Controller(),
@@ -337,7 +326,8 @@ CtlraScript::CtlraScript(std::string file) :
 	}
 
 	// TODO: rework accept dev to new signature
-	//int num_devs = ctlra_probe(dev, accept_dev_func, this);
+	int num_devs = ctlra_probe(dev, accept_dev_func, this);
+	LUPPP_NOTE("Num devs %d\n", num_devs);
 
 	stat = CONTROLLER_OK;
 }

--- a/src/controller/ctlra.hxx
+++ b/src/controller/ctlra.hxx
@@ -66,6 +66,8 @@ public:
 		return "CtlraScript";
 	}
 
+	virtual void poll();
+
 	const char *getCtlraName(int type, int id);
 
 	void barBeat(int bar, int beat);

--- a/src/controller/ctlra.hxx
+++ b/src/controller/ctlra.hxx
@@ -1,0 +1,110 @@
+/*
+ * Author: Harry van Haaren 2018
+ *         harryhaaren@gmail.com
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#ifndef LUPPP_CTLRA_H
+#define LUPPP_CTLRA_H
+
+#include "controller.hxx"
+
+#include <ctlra/ctlra.h>
+#include <ctlra/event.h>
+
+#include "../observer/midi.hxx"
+
+#include "luppp_script_api.h"
+
+/** This is a controller using TCC as a backend, which reads .c files
+ * as "scripts", but compiles them on the fly and then hooks in the
+ * poll / handle event loop into the controller itself.
+ *
+ * It is designed to be a flexible way of prototyping support for any
+ * MIDI/HID devices. Once a controller file is concidered "finished",
+ * it may be sent as a pull request for inclusion in vanilla Luppp.
+ *
+ * As TCC is only a C compiler (as opposed to C++) this layer translates
+ * Luppps internal events (which are C++ classes) to native C structs,
+ * which can then be passed to the TCC compiled C backend. Ideally the
+ * Luppp internal event handling system would be ported to plain C,
+ * however this would also require significant effort, which does not
+ * seem worth the time at the moment.
+ */
+
+/* These typedefs are for the poll and handle events of the scripted
+ * controller, to receieve and send events as needed */
+/* Handle incoming events from Ctlra controllers */
+typedef int (*tcc_event_func_t)(int num, struct ctlra_event_t **);
+/* Handle incoming Luppp events - and send responses to controller */
+typedef void (*ctlra_handle_event)(void *ctlra, enum EVENT_ID id, void *);
+
+class CtlraScript : public Controller, public MidiIO
+{
+public:
+	CtlraScript(std::string filename);
+	virtual ~CtlraScript();
+
+	/* called to register this instance with JACK */
+	int registerComponents();
+
+	std::string getName()
+	{
+		return "CtlraScript";
+	}
+
+	const char *getCtlraName(int type, int id);
+
+	void barBeat(int bar, int beat);
+	void trackSendActive(int t, int send, bool a);
+	void setSceneState(int track, int scene, GridLogic::State s);
+
+	void poll_devices();/* for ctlra poll() */
+	void midi(unsigned char* midi);
+	void ctlra_forward(struct ctlra_dev_t* dev, uint32_t num_events,
+			   struct ctlra_event_t** events);
+	void writeCtlraLight(int light,int status);
+
+	Controller::STATUS status();
+
+private:
+	/* a flag stating if the program linked OK. If not, we do not act
+	 * on the script, and do not call *any* function pointers related
+	 * to the script, as they *will* cause a segfault */
+	int program_ok;
+
+	void *program;
+	tcc_event_func_t tcc_event_func;
+	ctlra_handle_event handle;
+
+	std::string filename;
+
+	Controller::STATUS stat;
+
+	int compile();
+	void script_reload();
+
+	/* Ctlra stuff */
+	struct ctlra_t* dev;
+	void* hack_current_dev;
+
+	/* For tracking when to re-load the script file, this allows
+	 * taking the modified time, and recompiling when needed */
+	time_t script_load_time;
+};
+
+#endif // LUPPP_CTLRA_H
+

--- a/src/controller/luppp_script_api.h
+++ b/src/controller/luppp_script_api.h
@@ -1,0 +1,111 @@
+/*
+ * Author: Harry van Haaren 2018
+ *         harryhaaren@gmail.com
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#ifndef LUPPP_SCRIPT_API_H
+#define LUPPP_SCRIPT_API_H
+
+/**
+ * This file is the API for the Controller Scripts, allowing them to
+ * understand the events that have occurred in Luppp, and should be shown
+ * on the hardware device. Similarly, this API provides functions to send
+ * events to Luppp, which allow controlling of Luppp from the hardware.
+ */
+
+enum EVENT_ID {
+	EVENT_NOP = 0,
+	/* Track Events */
+	EVENT_TRACK_RECORD_ARM,
+	EVENT_TRACK_VOLUME,
+	EVENT_TRACK_SEND,
+	EVENT_TRACK_SEND_ACTIVE,
+	EVENT_TRACK_JACKSEND,
+	EVENT_TRACK_JACKSEND_ACTIVE,
+	/* Grid Events */
+	EVENT_GRID_PRESS_RELEASE,
+	EVENT_GRID_LAUNCH_SCENE,
+	/* Tempo Events */
+	EVENT_TEMPO_BPM,
+	EVENT_TEMPO_TAP,
+	/* Master Track */
+	EVENT_MASTER_VOLUME,
+	EVENT_MASTER_RETURN,
+	/* Time */
+	EVENT_TIME_BAR_BEAT,
+};
+
+struct event_track_record_arm {
+	int track;
+	int armed;
+};
+struct event_track_jack_send {
+	int track;
+	float value;
+};
+struct event_track_jack_send_active {
+	int track;
+	int active;
+};
+struct event_track_volume {
+	int track;
+	float value;
+};
+struct event_track_send {
+	int track;
+	int send;
+	float value;
+};
+struct event_track_send_active {
+	int track;
+	int send;
+	int active;
+};
+struct event_grid_launch_scene {
+	int scene;
+};
+struct event_grid_press_release {
+	int track;
+	int scene;
+	int pressed;
+};
+struct event_tempo_bpm {
+	float bpm;
+};
+struct event_tempo_tap {
+	int pressed; /* can be used to turn controller LED on/off */
+};
+struct event_master_volume {
+	float volume;
+};
+struct event_master_return {
+	float volume;
+};
+
+/* Read only events : aka, sending to Luppp won't have any effect. These
+ * are used only so controllers can display status from Luppp */
+struct event_time_bar_beat {
+	int bar;
+	int beat;
+};
+
+void luppp_do(enum EVENT_ID id, void* event_struct);
+void luppp_write_midi(void *ctlr, unsigned char* midi);
+void luppp_write_ctlra_light(void *ctlr, int light, int light_status);
+
+#endif /* LUPPP_SCRIPT_API_H */
+

--- a/src/controller/meson.build
+++ b/src/controller/meson.build
@@ -1,5 +1,6 @@
 luppp_src += files(
   'controller.cxx',
+  'ctlra.cxx',
   'genericmidi.cxx',
   'guicontroller.cxx',
   'nonseq.cxx'

--- a/src/controllerupdater.cxx
+++ b/src/controllerupdater.cxx
@@ -74,6 +74,13 @@ Controller* ControllerUpdater::getController(int id)
 	return 0;
 }
 
+void ControllerUpdater::poll()
+{
+	for(unsigned int i = 0; i < c.size(); i++)
+		c.at(i)->poll();
+}
+
+
 void ControllerUpdater::reset()
 {
 	for(unsigned int i = 0; i < c.size(); i++)

--- a/src/controllerupdater.hxx
+++ b/src/controllerupdater.hxx
@@ -55,6 +55,7 @@ public:
 	/// returns a Controller* from ID
 	Controller* getController(int id);
 
+	void poll();
 	void reset();
 	void mute(int t, bool b);
 

--- a/src/gui.cxx
+++ b/src/gui.cxx
@@ -32,6 +32,7 @@ extern Jack* jack;
 #include "audiobuffer.hxx"
 #include "controller/nonseq.hxx"
 #include "controller/genericmidi.hxx"
+#include "controller/ctlra.hxx"
 
 #include "icon.xpm"
 #include <FL/x.H>
@@ -468,6 +469,17 @@ Gui::Gui(const char* argZero) :
 		LUPPP_WARN("No preferences loaded, using defaults.");
 	} else {
 		LUPPP_NOTE("Loaded preferences");
+	}
+
+	// Ctlra init stuff
+	LUPPP_NOTE("%s","Add Ctlra Controller in GUI()");
+	std::string ctlra_path = "ctlra_test.c";
+	Controller* c = new CtlraScript( ctlra_path );
+	if ( c->status() == Controller::CONTROLLER_OK ) {
+		EventControllerInstance e(c);
+		writeToDspRingbuffer( &e );
+	} else {
+		LUPPP_ERROR("Ctlra Controller initialization failed!");
 	}
 
 	// NSM stuff

--- a/src/jack.cxx
+++ b/src/jack.cxx
@@ -459,13 +459,14 @@ int Jack::process (jack_nframes_t nframes)
 		}
 	}
 
-
 	//buffers.midi [Buffers::MASTER_MIDI_INPUT]   = (void*) jack_port_get_buffer( masterMidiInput, nframes );
 
 	/// init buffers for each MidiIO
 	for(unsigned int i = 0; i < midiIO.size(); i++ ) {
 		midiIO.at(i)->initBuffers( nframes );
 	}
+
+	controllerUpdater->poll();
 
 	/// do events from the ringbuffer
 	handleDspEvents();


### PR DESCRIPTION
Initial implementation of Ctlra support for Luppp. This is based on POC code from ~2016, when the Ctlra library was being designed. Since then the API has seen lots of updates, and these commits hack those changes into Luppp.

Note that the actual architecture of the current implementation is not correct, as the ctlra_idle_poll() function is called from the real-time audio context. This means that these patches are *NOT* ready for use on stage, as they *WILL* cause glitches and Xruns when Ctlra enabled devices are plugged into your system.

This PR is here to show the workings of Ctlra and Luppp - and to allow alpha testers etc to get access to the codebase. More commits will be pushed as time permits! -H