### PR TITLE
Sanity check for bpm input

### DIFF
--- a/src/config.hxx
+++ b/src/config.hxx
@@ -51,6 +51,10 @@
 #define NSCENES 10
 #define MAX_BUFFER_SIZE 1024
 
+///     TEMPO
+#define MIN_TEMPO 60
+#define MAX_TEMPO 220
+
 #define CONTROLLERS_PREALLOC 20
 
 // nsamples remaining during recording before Looper requests larger buffer

--- a/src/gmastertrack.cxx
+++ b/src/gmastertrack.cxx
@@ -23,7 +23,7 @@
 static void gmastertrack_tempoDial_callback(Fl_Widget *w, void *data)
 {
 	Avtk::Dial* b = (Avtk::Dial*)w;
-	float bpm = (int)(b->value() * 160.f + 60);
+	float bpm = (int)(b->value() * (float)(MAX_TEMPO - MIN_TEMPO) + MIN_TEMPO);
 	if(std::fabs(bpm-round(bpm))) {
 		LUPPP_WARN("%f",bpm);
 	}
@@ -269,7 +269,7 @@ GMasterTrack::GMasterTrack(int x, int y, int w, int h, const char* l ) :
 void GMasterTrack::setBpm( int b )
 {
 	bpm = b;
-	tempoDial.value( ( bpm - 60 ) / 160.f );
+	tempoDial.value( ( bpm - MIN_TEMPO ) / (float)(MAX_TEMPO-MIN_TEMPO) );
 	std::stringstream s;
 	s << bpm;
 	tempoDial.copy_label( s.str().c_str() );

--- a/src/gmastertrack.cxx
+++ b/src/gmastertrack.cxx
@@ -173,8 +173,11 @@ static void gmastertrack_button_callback(Fl_Widget *w, void *data)
 			const char* answer = fl_input("Enter BPM value: ");
 			if(answer) {
 				int bpm = atoi(answer);
-				EventTimeBPM e = EventTimeBPM( bpm );
-				writeToDspRingbuffer( &e );
+				
+				if ( bpm >= MIN_TEMPO && bpm <= MAX_TEMPO) {
+					EventTimeBPM e = EventTimeBPM( bpm );
+					writeToDspRingbuffer( &e );
+				}
 			}
 		} else {
 			EventTimeTempoTap e;

--- a/src/gmastertrack.cxx
+++ b/src/gmastertrack.cxx
@@ -170,8 +170,7 @@ static void gmastertrack_button_callback(Fl_Widget *w, void *data)
 
 	} else if ( strcmp( w->label(), "Tap" ) == 0 ) {
 		if ( Fl::event_button() == FL_RIGHT_MOUSE ) {
-			string question = "Enter BPM value (between " + to_string(MIN_TEMPO) + " and " + to_string(MAX_TEMPO) + "):";
-			const char* answer = fl_input(question.c_str());
+			const char* answer = fl_input("Enter BPM value (range %d and %d):", 0, MIN_TEMPO, MAX_TEMPO);
 			if(answer) {
 				int bpm = atoi(answer);
 				

--- a/src/gmastertrack.cxx
+++ b/src/gmastertrack.cxx
@@ -170,7 +170,9 @@ static void gmastertrack_button_callback(Fl_Widget *w, void *data)
 
 	} else if ( strcmp( w->label(), "Tap" ) == 0 ) {
 		if ( Fl::event_button() == FL_RIGHT_MOUSE ) {
-			const char* answer = fl_input("Enter BPM value: ");
+			string question = "Enter BPM value (between " + to_string(MIN_TEMPO) + " and " 
+								+ to_string(MAX_TEMPO) + "):";
+			const char* answer = fl_input(question.c_str());
 			if(answer) {
 				int bpm = atoi(answer);
 				

--- a/src/gmastertrack.cxx
+++ b/src/gmastertrack.cxx
@@ -170,8 +170,7 @@ static void gmastertrack_button_callback(Fl_Widget *w, void *data)
 
 	} else if ( strcmp( w->label(), "Tap" ) == 0 ) {
 		if ( Fl::event_button() == FL_RIGHT_MOUSE ) {
-			string question = "Enter BPM value (between " + to_string(MIN_TEMPO) + " and " 
-								+ to_string(MAX_TEMPO) + "):";
+			string question = "Enter BPM value (between " + to_string(MIN_TEMPO) + " and " + to_string(MAX_TEMPO) + "):";
 			const char* answer = fl_input(question.c_str());
 			if(answer) {
 				int bpm = atoi(answer);
@@ -274,7 +273,7 @@ GMasterTrack::GMasterTrack(int x, int y, int w, int h, const char* l ) :
 void GMasterTrack::setBpm( int b )
 {
 	bpm = b;
-	tempoDial.value( ( bpm - MIN_TEMPO ) / (float)(MAX_TEMPO-MIN_TEMPO) );
+	tempoDial.value( ( bpm - MIN_TEMPO ) / (float)(MAX_TEMPO - MIN_TEMPO) );
 	std::stringstream s;
 	s << bpm;
 	tempoDial.copy_label( s.str().c_str() );


### PR DESCRIPTION
Alright, i thought about a little and this is my solution. 

There are two "features" included here:
- change limits for possible bpm-value in config.hxx (first commit)
- check if custom bpm value is in the limit (second commit)

The third commit is needed because if you enter values <60 or >220, it just dont work without any user feedback. I dont know if this string-stuff is "nice" coded, but its working. if there are any complains about (eg speed or something) please let me know. (Sadly i dont have internet access and cant get into the topic at the moment).
Maybe it would be an good idea to tell the user if the input is "wrong", but i didnt wanted to let the popup pop up again and as far as i can see there is no implemented way to tell the user that something gone wrong, is it?

Happy if this could be merged or for any feedback. 