### PR TITLE
found two more hard coded bpm limits

### DIFF
--- a/src/controller/genericmidi.cxx
+++ b/src/controller/genericmidi.cxx
@@ -547,7 +547,7 @@ void GenericMIDI::midi(unsigned char* midi)
 				break;
 			case Event::TIME_BPM:
 				// FIXME: quick-fix for "ZeroOne" type value -> BPM range
-				jack->getLogic()->setBpm( value * 160 + 60 );
+				jack->getLogic()->setBpm( value * (MAX_TEMPO - MIN_TEMPO) + MIN_TEMPO );
 				break;
 			case Event::METRONOME_ACTIVE:
 				jack->getLogic()->metronomeEnable( b->active );

--- a/src/timemanager.cxx
+++ b/src/timemanager.cxx
@@ -82,7 +82,7 @@ void TimeManager::setBpm(float bpm)
 
 void TimeManager::setBpmZeroOne(float b)
 {
-	setBpm( b * 160 + 60 ); // 60 - 220
+	setBpm( b * (MAX_TEMPO - MIN_TEMPO) + MIN_TEMPO ); // 60 - 220
 }
 
 


### PR DESCRIPTION
self explaining. But by the way, what is meant by this "ZeroOne" stuff? There is an FIXME:
// FIXME: quick-fix for "ZeroOne" type value -> BPM range

maybe this is already resolved?