### PR TITLE
Replace all hard coded scene numbers

### DIFF
--- a/src/avtk/avtk_unit.h
+++ b/src/avtk/avtk_unit.h
@@ -76,7 +76,7 @@ public:
 		clips[5].state = UnitState::UNIT_STOPPING;
 	}
 
-	static const int numClips = 10;
+	static const int numClips = NSCENES;
 	UnitState clips[numClips];
 
 	bool mouseOver;

--- a/src/avtk/clipselector.cxx
+++ b/src/avtk/clipselector.cxx
@@ -45,7 +45,7 @@ ClipSelector::ClipSelector( int _x, int _y, int _w, int _h,
 	_master = master;
 
 	if ( _master ) {
-		for(int i = 0; i < 10; i++ ) {
+		for(int i = 0; i < NSCENES; i++ ) {
 			stringstream s;
 			s << "Scene " << i + 1;
 			clips[i].setName( s.str() );

--- a/src/avtk/clipselector.hxx
+++ b/src/avtk/clipselector.hxx
@@ -77,8 +77,7 @@ public:
 
 	int ID;
 
-	// FIXME: NSCENES?
-	static const int numClips = 10;
+	static const int numClips = NSCENES;
 	ClipState clips[numClips];
 
 	/// indicates if a clip is the "special" clip

--- a/src/looper.cxx
+++ b/src/looper.cxx
@@ -42,7 +42,7 @@ Looper::Looper(int t) :
 	//tmpRecordBuffer = (float*)malloc( sizeof(float) * MAX_BUFFER_SIZE );
 	//memset( tmpRecordBuffer, 0, sizeof(float) * MAX_BUFFER_SIZE );
 
-	for(int i = 0; i < 10; i++ ) {
+	for(int i = 0; i < NSCENES; i++ ) {
 		clips[i] = new LooperClip(track, i);
 	}
 

--- a/src/looper.hxx
+++ b/src/looper.hxx
@@ -70,7 +70,7 @@ private:
 	int fpb;
 
 	//vector<float> tmpRecordBuffer;
-	LooperClip* clips[10];
+	LooperClip* clips[NSCENES];
 
 	// Pitch Shifting
 	void pitchShift(int count, float* input, float* output);


### PR DESCRIPTION
In this PR i replaced all hard coded Scene numbers by NSCENES from the config.h. This way the number of tracks and scenes can be changed on compile time. 

This is the first step in getting luppp running with custom number of tracks and scenes. Currently, it is working, but the GUI gets wrong. But this should be another, following PR. I hope i found all hard coded numbers, but luppp seems to work with custom values so i guess i found everything. I also searched for 8 and 10 in the hole repository and replaced everything. 

There is just one file left: /home/georg/workspace/openAV-Luppp/src/tests/lupppTestMaterial/lupppTest/session.luppp which contains hard coded number of sceneNames and tracks. But there is no easy way to repair this. (In this moment it gets in my mind to try to load this session with changed number of tracks and scenes to see what happens.)