### PR TITLE
Cleanup

### DIFF
--- a/src/controller/genericmidi.cxx
+++ b/src/controller/genericmidi.cxx
@@ -546,8 +546,7 @@ void GenericMIDI::midi(unsigned char* midi)
 				jack->getLogic()->tapTempo();
 				break;
 			case Event::TIME_BPM:
-				// FIXME: quick-fix for "ZeroOne" type value -> BPM range
-				jack->getLogic()->setBpm( value * (MAX_TEMPO - MIN_TEMPO) + MIN_TEMPO );
+				jack->getLogic()->setBpmZeroOne( value );
 				break;
 			case Event::METRONOME_ACTIVE:
 				jack->getLogic()->metronomeEnable( b->active );

--- a/src/logic.cxx
+++ b/src/logic.cxx
@@ -41,6 +41,11 @@ void Logic::setBpm(float bpm)
 	jack->getTimeManager()->setBpm( bpm );
 }
 
+void Logic::setBpmZeroOne(float bpm)
+{
+	jack->getTimeManager()->setBpmZeroOne( bpm );
+}
+
 void Logic::metronomeEnable(bool b)
 {
 	jack->getMetronome()->setActive(b);

--- a/src/logic.hxx
+++ b/src/logic.hxx
@@ -42,7 +42,8 @@ public:
 	Logic();
 
 	void tapTempo();
-	void setBpm(float bpm); /// 0-1 input
+	void setBpm(float bpm); // actual BPM input
+	void setBpmZeroOne( float bpm ); /// 0-1 input
 
 	void metronomeEnable(bool b);
 

--- a/src/timemanager.cxx
+++ b/src/timemanager.cxx
@@ -82,7 +82,7 @@ void TimeManager::setBpm(float bpm)
 
 void TimeManager::setBpmZeroOne(float b)
 {
-	setBpm( b * (MAX_TEMPO - MIN_TEMPO) + MIN_TEMPO ); // 60 - 220
+	setBpm( b * (MAX_TEMPO - MIN_TEMPO) + MIN_TEMPO ); // MIN_TEMPO - MAX_TEMPO
 }
 
 


### PR DESCRIPTION
Did some cleanup on my BPM-Stuff and tried to standartise workflow by using the TimeManager::setBpmZeroOne function to do the calculation if possible. 

Question: Why do we need this detour across the logic function? 

```jack->getLogic()->setBpmZeroOne( value );```

We could also do

```jack->getTimeManager()->setBpmZeroOne( value );```

which seems to be more direct for me. The midi-function is the only place where the Logic::setBpm Function is called and could be removed. This way all tempo related stuff could be removed from Logic, which simplifies the design from my point of view. 