### PR TITLE
sets default binding active to 1

### DIFF
--- a/src/controller/binding.hxx
+++ b/src/controller/binding.hxx
@@ -28,7 +28,7 @@ typedef int LupppAction;
 class Binding
 {
 public:
-	Binding() : status(0), data(0), action(0), active(-1),
+	Binding() : status(0), data(0), action(0), active(1),
 		track(-2),scene(-1),send(-1)
 	{
 		ID = privateID++;

--- a/src/jack.cxx
+++ b/src/jack.cxx
@@ -71,7 +71,7 @@ void Jack::resetMidiBindingState()
 	bindingTrack = -2;
 	bindingScene = -1;
 	bindingSend  = -1;
-	bindingActive= -1;
+	bindingActive= 1;
 }
 
 Jack::Jack( std::string name ) :


### PR DESCRIPTION
Since the active fields need to be `-1` for clearing a clip, we took away the ability to set active to an illegal value. Thats why we need another default value, and i think the best would be the normal grid event like it was before. So i set this to `1`, which fixes #134 