### PR TITLE
repair trackconfusion

### DIFF
--- a/src/config.hxx
+++ b/src/config.hxx
@@ -49,6 +49,7 @@
 ///     GENERAL
 #define NTRACKS 8
 #define NSCENES 10
+#define NCHANNELS 2
 #define MAX_BUFFER_SIZE 1024
 
 ///     TEMPO

--- a/src/jack.cxx
+++ b/src/jack.cxx
@@ -546,7 +546,7 @@ void Jack::processFrames(int nframes)
 			buffers.audio[Buffers::SEND_R][i] += inputR * inputToSendVol * inputToMixVol;
 		}
 		if ( inputToKeyEnable ) {
-			buffers.audio[Buffers::SIDECHAIN_KEY_R][i] += inputL;
+			buffers.audio[Buffers::SIDECHAIN_KEY_L][i] += inputL;
 			buffers.audio[Buffers::SIDECHAIN_KEY_R][i] += inputR;
 		}
 

--- a/src/jack.cxx
+++ b/src/jack.cxx
@@ -624,7 +624,7 @@ void Jack::processFrames(int nframes)
 			for(int t=0; t<NTRACKS; t++) {
 				int o = t*2;
 				buffers.audio[Buffers::JACK_TRACK_0_L+o]   = &buffers.audio[Buffers::JACK_TRACK_0_L+o][nframes];
-				buffers.audio[Buffers::JACK_TRACK_0_L+o+1] = &buffers.audio[Buffers::JACK_TRACK_0_L+o+1][nframes];
+				buffers.audio[Buffers::JACK_TRACK_0_R+o]   = &buffers.audio[Buffers::JACK_TRACK_0_R+o][nframes];
 			}
 		}
 	} else

--- a/src/jacksendreturn.cxx
+++ b/src/jacksendreturn.cxx
@@ -22,14 +22,15 @@ JackSendReturn::JackSendReturn(int trackid, AudioProcessor *prev, jack_client_t 
 
 void JackSendReturn::process(unsigned int nframes, Buffers *buffers)
 {
+	int trackoffset = m_trackid * 2;
 	//Reset send buffer
 	int offset=m_counter%(buffers->nframes);
-	float* sendtrackL=&(buffers->audio[Buffers::SEND_TRACK_0_L+m_trackid][0]);
-	float* sendtrackR=&(buffers->audio[Buffers::SEND_TRACK_0_R+m_trackid][0]);
+	float* sendtrackL=&(buffers->audio[Buffers::SEND_TRACK_0_L + trackoffset][0]);
+	float* sendtrackR=&(buffers->audio[Buffers::SEND_TRACK_0_R + trackoffset][0]);
 
 
-	float* rettrackL=&(buffers->audio[Buffers::RETURN_TRACK_0_L+m_trackid][0]);
-	float* rettrackR=&(buffers->audio[Buffers::RETURN_TRACK_0_R+m_trackid][0]);
+	float* rettrackL=&(buffers->audio[Buffers::RETURN_TRACK_0_L + trackoffset][0]);
+	float* rettrackR=&(buffers->audio[Buffers::RETURN_TRACK_0_R + trackoffset][0]);
 
 	memset(sendtrackL,0,nframes*sizeof(float));
 	memset(sendtrackR,0,nframes*sizeof(float));

--- a/src/jacksendreturn.cxx
+++ b/src/jacksendreturn.cxx
@@ -22,7 +22,8 @@ JackSendReturn::JackSendReturn(int trackid, AudioProcessor *prev, jack_client_t 
 
 void JackSendReturn::process(unsigned int nframes, Buffers *buffers)
 {
-	int trackoffset = m_trackid * 2;
+	// index = first-track + (track * channels)
+	int trackoffset = m_trackid * NCHANNELS;
 	//Reset send buffer
 	int offset=m_counter%(buffers->nframes);
 	float* sendtrackL=&(buffers->audio[Buffers::SEND_TRACK_0_L + trackoffset][0]);

--- a/src/looper.cxx
+++ b/src/looper.cxx
@@ -131,8 +131,9 @@ void Looper::process(unsigned int nframes, Buffers* buffers)
 				playSpeed = float(actualFrames) / targetFrames;
 			}
 
-			float* outL = buffers->audio[Buffers::SEND_TRACK_0_L + track];
-			float* outR = buffers->audio[Buffers::SEND_TRACK_0_R + track];
+			int trackoffset = track * 2;
+			float* outL = buffers->audio[Buffers::SEND_TRACK_0_L + trackoffset];
+			float* outR = buffers->audio[Buffers::SEND_TRACK_0_R + trackoffset];
 
 			for(unsigned int i = 0; i < nframes; i++ ) {
 				// REFACTOR into system that is better than per sample function calls

--- a/src/looper.cxx
+++ b/src/looper.cxx
@@ -131,7 +131,8 @@ void Looper::process(unsigned int nframes, Buffers* buffers)
 				playSpeed = float(actualFrames) / targetFrames;
 			}
 
-			int trackoffset = track * 2;
+			// index = first-track + (track * channels)
+			int trackoffset = track * NCHANNELS;
 			float* outL = buffers->audio[Buffers::SEND_TRACK_0_L + trackoffset];
 			float* outR = buffers->audio[Buffers::SEND_TRACK_0_R + trackoffset];
 

--- a/src/trackoutput.cxx
+++ b/src/trackoutput.cxx
@@ -110,7 +110,8 @@ void TrackOutput::setSend( int send, float value )
 
 void TrackOutput::process(unsigned int nframes, Buffers* buffers)
 {
-	int trackoffset = track * 2; // because we use stereo now, we need to skip two buffers per track
+	// index = first-track + (track * channels)
+	int trackoffset = track * NCHANNELS;
 
 	//compute master volume lag;
 	if(fabs(_toMaster-_toMasterLag)>=fabs(_toMasterDiff/100.0))

--- a/src/trackoutput.cxx
+++ b/src/trackoutput.cxx
@@ -110,12 +110,14 @@ void TrackOutput::setSend( int send, float value )
 
 void TrackOutput::process(unsigned int nframes, Buffers* buffers)
 {
+	int trackoffset = track * 2; // because we use stereo now, we need to skip two buffers per track
+
 	//compute master volume lag;
 	if(fabs(_toMaster-_toMasterLag)>=fabs(_toMasterDiff/100.0))
 		_toMasterLag+=_toMasterDiff/10.0;
 	// get & zero track buffer
-	float* trackBufferL = buffers->audio[Buffers::RETURN_TRACK_0_L + track];
-	float* trackBufferR = buffers->audio[Buffers::RETURN_TRACK_0_R + track];
+	float* trackBufferL = buffers->audio[Buffers::RETURN_TRACK_0_L + trackoffset];
+	float* trackBufferR = buffers->audio[Buffers::RETURN_TRACK_0_R + trackoffset];
 	memset( trackBufferL, 0, sizeof(float)*nframes );
 	memset( trackBufferR, 0, sizeof(float)*nframes );
 
@@ -147,8 +149,8 @@ void TrackOutput::process(unsigned int nframes, Buffers* buffers)
 	float* masterR       = buffers->audio[Buffers::MASTER_OUT_R];
 
 
-	float* jackoutputL    = buffers->audio[Buffers::JACK_TRACK_0_L+track];
-	float* jackoutputR    = buffers->audio[Buffers::JACK_TRACK_0_R+track];
+	float* jackoutputL    = buffers->audio[Buffers::JACK_TRACK_0_L + trackoffset];
+	float* jackoutputR    = buffers->audio[Buffers::JACK_TRACK_0_R + trackoffset];
 
 	/* Trial + Error leads to this algo - its cheap and cheerful */
 	float pan_l = 1.0f;


### PR DESCRIPTION
This PR adresses #220. 

To explain: When we/someone built the stereo signal chain in luppp, the way to access buffers needed to change. Before stereo, we could simply do `buffer[ first_track + current_track]`. But since there are two Buffers for each track, eg Left and Right, we need to skip 2 buffers for each track. This PR changes all buffer reads to go this way: `buffer[ first_track + current_track * 2]`

We could also change the order of the buffers in buffers.hxx to
track_1_l
track_2_l
...
track_1_r
track_2_r

but this PR seems to be the better solution for me.

Thanks to @coderkun for the help.

Before we merge i would like to have some more tests from other users.