### PR TITLE
Fix Input Signal Flow

### DIFF
--- a/src/jack.cxx
+++ b/src/jack.cxx
@@ -539,11 +539,12 @@ void Jack::processFrames(int nframes)
 			float tmpR = inputR * inputToMixVol * (1-inputToXSideVol);
 			L += tmpL;
 			R += tmpR;
-		}
-		if ( inputToSendEnable ) {
-			// post-mix-send amount: hence * inputToMixVol
-			buffers.audio[Buffers::SEND_L][i] += inputL * inputToSendVol * inputToMixVol;
-			buffers.audio[Buffers::SEND_R][i] += inputR * inputToSendVol * inputToMixVol;
+			
+			if ( inputToSendEnable ) {
+				// post-mix-send amount: hence * inputToMixVol
+				buffers.audio[Buffers::SEND_L][i] += inputL * inputToSendVol * inputToMixVol;
+				buffers.audio[Buffers::SEND_R][i] += inputR * inputToSendVol * inputToMixVol;
+			}
 		}
 		if ( inputToKeyEnable ) {
 			buffers.audio[Buffers::SIDECHAIN_KEY_R][i] += inputL;

--- a/src/jack.hxx
+++ b/src/jack.hxx
@@ -101,6 +101,11 @@ public:
 	{
 		return controllerUpdater;
 	}
+	
+	float getInputVolume() 
+	{
+		return inputVol;
+	}
 
 	void transportRolling(bool rolling);
 

--- a/src/looper.cxx
+++ b/src/looper.cxx
@@ -118,8 +118,8 @@ void Looper::process(unsigned int nframes, Buffers* buffers)
 			}
 
 			// copy data from input buffer to recording buffer
-			float* inputL = buffers->audio[Buffers::MASTER_INPUT_L];
-			float* inputR = buffers->audio[Buffers::MASTER_INPUT_R];
+			float* inputL = buffers->audio[Buffers::MASTER_INPUT_L] * jack->getInputVolume;
+			float* inputR = buffers->audio[Buffers::MASTER_INPUT_R] * jack->getInputVolume;
 			clips[clip]->record( nframes, inputL, inputR);
 		} else if ( clips[clip]->playing() ) {
 			// copy data into tmpBuffer, then pitch-stretch into track buffer

--- a/src/looper.cxx
+++ b/src/looper.cxx
@@ -118,8 +118,14 @@ void Looper::process(unsigned int nframes, Buffers* buffers)
 			}
 
 			// copy data from input buffer to recording buffer
-			float* inputL = buffers->audio[Buffers::MASTER_INPUT_L] * jack->getInputVolume;
-			float* inputR = buffers->audio[Buffers::MASTER_INPUT_R] * jack->getInputVolume;
+			float* inputL = buffers->audio[Buffers::MASTER_INPUT_L];
+			float* inputR = buffers->audio[Buffers::MASTER_INPUT_R];
+
+			for (unsigned int i = 0; i < nframes; i++ ) {
+				inputL[i] *= jack->getInputVolume();
+				inputR[i] *= jack->getInputVolume();
+			}
+
 			clips[clip]->record( nframes, inputL, inputR);
 		} else if ( clips[clip]->playing() ) {
 			// copy data into tmpBuffer, then pitch-stretch into track buffer


### PR DESCRIPTION
This PR adresses #228. 

The first commit prevents the input getting piped to the Sends if the Mix-Button is turned off. From my point of view it does not make any sense to apply an effect to a signal you dont hear at the moment. 

The second commit applys the input volume fader also to the recordings, so you can adjust the volume of the recorded clips.

These are not so big changes, i did some testing and everything should work. So this should be ready for merging.