### PR TITLE
calculate tempo related numbers on higher precision

### DIFF
--- a/src/looper.cxx
+++ b/src/looper.cxx
@@ -31,6 +31,7 @@
 #include "audiobuffer.hxx"
 #include "eventhandler.hxx"
 #include "controllerupdater.hxx"
+#include "timemanager.hxx"
 
 extern Jack* jack;
 
@@ -52,7 +53,7 @@ Looper::Looper(int t) :
 
 	tmpBuffer.resize( MAX_BUFFER_SIZE );
 
-	fpb = 22050;
+	fpb = jack->getTimeManager()->getFpb();
 
 	// init faust pitch shift variables
 	fSamplingFreq = jack->getSamplerate();
@@ -101,7 +102,7 @@ void Looper::setRequestedBuffer(int s, AudioBuffer* ab)
 	clips[s]->setRequestedBuffer( ab );
 }
 
-void Looper::setFpb(int f)
+void Looper::setFpb(double f)
 {
 	fpb = f;
 }
@@ -135,10 +136,14 @@ void Looper::process(unsigned int nframes, Buffers* buffers)
 			// copy data into tmpBuffer, then pitch-stretch into track buffer
 			long targetFrames = clips[clip]->getBeats() * fpb;
 			long actualFrames = clips[clip]->getActualAudioLength();//getBufferLenght();
-			float playSpeed = 1.0;
+#ifdef DEBUG_TIME
+				cout << "FPB: " << fpb << "\n";
+				cout << "Target: " << targetFrames << " - Actual: " << actualFrames << "\n";
+#endif
+			long double playSpeed = 1.0;
 
 			if ( targetFrames != 0 && actualFrames != 0 ) {
-				playSpeed = float(actualFrames) / targetFrames;
+				playSpeed = (long double)(actualFrames) / (long double)(targetFrames);
 
 #ifdef DEBUG_TIME
 					cout << fixed << setprecision(20) << playSpeed << "\n";

--- a/src/looper.hxx
+++ b/src/looper.hxx
@@ -45,7 +45,7 @@ public:
 	void setRequestedBuffer(int s, AudioBuffer* ab);
 
 	/// stores the framesPerBeat from TimeManager. Used to stretch audio
-	void setFpb(int f);
+	void setFpb(double f);
 
 	/// Retrieve a clip from the Looper
 	LooperClip* getClip(int scene);
@@ -67,7 +67,7 @@ private:
 	int playingScene;
 	int queuedScene;
 
-	int fpb;
+	double fpb;
 
 	//vector<float> tmpRecordBuffer;
 	LooperClip* clips[NSCENES];

--- a/src/looperclip.cxx
+++ b/src/looperclip.cxx
@@ -429,7 +429,7 @@ bool LooperClip::newBufferInTransit()
 	return _newBufferInTransit;
 }
 
-void LooperClip::getSample(float playSpeed, float* L, float* R)
+void LooperClip::getSample(long double playSpeed, float* L, float* R)
 {
 	if ( _buffer && (_buffer->getSize() > 0)) {
 		if ( _playhead >= _recordhead ||
@@ -443,8 +443,8 @@ void LooperClip::getSample(float playSpeed, float* L, float* R)
 
 		std::vector<float>& vL = _buffer->getDataL();
 		std::vector<float>& vR = _buffer->getDataR();
-		*L = vL[_playhead];
-		*R = vR[_playhead];
+		*L = vL[_playhead+0.5];
+		*R = vR[_playhead+0.5];
 		_playhead += playSpeed;
 	} else {
 		*L = 0.f;

--- a/src/looperclip.hxx
+++ b/src/looperclip.hxx
@@ -55,7 +55,7 @@ public:
 	void load( AudioBuffer* ab );
 
 	/// audio functionality
-	void getSample(float playSpeed, float* L, float* R);
+	void getSample(long double playSpeed, float* L, float* R);
 	void record(int count, float* L, float* R);
 
 	/// TimeObserver override
@@ -138,7 +138,7 @@ private:
 
 	bool _newBufferInTransit;
 
-	float _playhead;
+	long double _playhead;
 	float _recordhead;
 
 	unsigned int _barsPlayed;

--- a/src/metronome.cxx
+++ b/src/metronome.cxx
@@ -88,7 +88,7 @@ void Metronome::beat()
 	playBar = false;
 }
 
-void Metronome::setFpb(int f)
+void Metronome::setFpb(double f)
 {
 	fpb = f;
 

--- a/src/metronome.hxx
+++ b/src/metronome.hxx
@@ -38,14 +38,14 @@ public:
 
 	void bar();
 	void beat();
-	void setFpb(int f);
+	void setFpb(double f);
 
 	void setVolume( float v );
 
 	void process(int nframes, Buffers* buffers);
 
 private:
-	int fpb;
+	double fpb;
 	bool playBar;
 	bool active;
 	float vol;

--- a/src/observer/time.hxx
+++ b/src/observer/time.hxx
@@ -28,7 +28,7 @@ public:
 	TimeObserver();
 	virtual ~TimeObserver() {};
 
-	virtual void setFpb(int fpb) {};
+	virtual void setFpb(double fpb) {};
 
 	//Reset any internal set of this object regarding time. Don't reset/delete any buffers!!
 	//This is not to be confused with Stately::reset()

--- a/src/timemanager.hxx
+++ b/src/timemanager.hxx
@@ -35,11 +35,11 @@ class TimeManager
 public:
 	TimeManager();
 
-	int getFpb();
+	double getFpb();
 	void queueBpmChange(float bpm);
 	void queueBpmChangeZeroOne(float bpm);
-	void queueFpbChange(float f);
-	void setFpb(float f);
+	void queueFpbChange(double f);
+	void setFpb(double f);
 
 	/// add a component to be updated for time events
 	void registerObserver(TimeObserver* o);
@@ -66,8 +66,8 @@ private:
 	TRANSPORT_STATE transportState;
 
 	/// number of frames per beat
-	int fpb;
-	int _nextFpb;
+	double _fpb;
+	double _nextFpb;
 
 	/// holds the number of frames processed
 	long long totalFrameCounter;


### PR DESCRIPTION
@harryhaaren this is now nearly perfect, I have offsets <1 sample on bar-reset. There might be some small issues left with resetting, but this should be an easy fix. Would be great to have this merged asap so our beloved power users are able to check if this is working