### PR TITLE
Mappa initial implementation

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -29,7 +29,8 @@ dep_names = [
   'jack',
   'sndfile',
   'samplerate',
-  'x11'
+  'x11',
+  'openav_ctlra'
   ]
 deps = []
 

--- a/resources/mappa/z1_mappa.ini
+++ b/resources/mappa/z1_mappa.ini
@@ -1,0 +1,47 @@
+# Author Metadata: who to send thanks to
+[author]
+name = Harry van Haaren
+email = harryhaaren@gmail.com
+organization = OpenAV
+
+# Describes the hardware that this config applys to. Serial can be used
+# to apply seperate configs to the same device. If no serial is present,
+# all devices will recieve the same configuration
+[hardware]
+vendor = Native Instruments
+device = Kontrol Z1
+serial = xyz123
+
+# Describe the software this mapping is for, including version it was
+# created on.
+[software]
+name = Luppp
+version = 1.1
+
+# Each layer is an independent set of mappings. The "mappa:layer switch"
+# target is provided by the mappa library, and allows the user to switch
+# between layers. This is transparent to the application, so no logic
+# changes are required in each application - Mappa just handles it.
+[layer.0]
+slider_count = 8
+slider.0 = luppp:track_0_vol
+slider.1 = luppp:track_1_vol
+slider.2 = luppp:track_2_vol
+slider.3 = luppp:track_3_vol
+slider.4 = luppp:track_4_vol
+slider.5 = luppp:track_5_vol
+slider.6 = luppp:track_6_vol
+slider.7 = luppp:track_7_vol
+button.0 = mappa:layer switch
+
+[layer.1]
+slider_count = 8
+slider.0 = luppp:track_0_send
+slider.1 = luppp:track_1_send
+slider.2 = luppp:track_2_send
+slider.3 = luppp:track_3_send
+slider.4 = luppp:track_4_send
+slider.5 = luppp:track_5_send
+slider.6 = luppp:track_6_send
+slider.7 = luppp:track_7_send
+button.1 = mappa:layer switch

--- a/src/gui.cxx
+++ b/src/gui.cxx
@@ -19,6 +19,7 @@
 #include "gui.hxx"
 #include "avtk/avtk_image.h"
 #include "avtk/avtk_button.h"
+#include "mappa.hxx"
 
 #include <sstream>
 
@@ -76,9 +77,19 @@ void close_cb(Fl_Widget*o, void*)
 		gui->quit();
 	}
 }
+
+int Gui::iter()
+{
+	mappa->iter();
+	return 0;
+}
+
 static void gui_static_read_rb(void* inst)
 {
 	handleGuiEvents();
+
+	Gui *gui = (Gui *)inst;
+	gui->iter();
 
 	Fl::repeat_timeout( 1 / 30.f, &gui_static_read_rb, inst);
 }
@@ -454,6 +465,8 @@ Gui::Gui(const char* argZero) :
 	// Create AudioEditor after window.end() has been called
 	audioEditor = new AudioEditor();
 
+	mappa = new Mappa();
+
 	// read settings file using diskreader, and setup controllers etc
 	int prefs = diskReader->loadPreferences();
 	if ( prefs != LUPPP_RETURN_OK ) {
@@ -495,6 +508,8 @@ void Gui::setupMidiControllers()
 			writeToDspRingbuffer( &e );
 		}
 	}
+
+	mappa->register_targets();
 }
 
 void Gui::reset()

--- a/src/gui.hxx
+++ b/src/gui.hxx
@@ -40,6 +40,8 @@
 // non-session-manager integration
 #include "nsm.h"
 
+// Ctlra/Mappa integration
+#include "mappa.hxx"
 
 using namespace std;
 
@@ -52,6 +54,8 @@ public:
 	~Gui();
 
 	int show();
+
+	int iter();
 
 	int quit();
 	void askQuit();
@@ -146,6 +150,8 @@ private:
 
 	// non-session-manager
 	nsm_client_t* nsm;
+
+	Mappa *mappa;
 
 	static int keyboardHandler(int event);
 };

--- a/src/mappa.cxx
+++ b/src/mappa.cxx
@@ -1,0 +1,105 @@
+/*
+ * Author: Harry van Haaren 2018
+ *         harryhaaren@gmail.com
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "mappa.hxx"
+
+#include "config.hxx"
+#include "eventhandler.hxx"
+
+#include <ctlra/mappa.h>
+
+#include <errno.h>
+#include <iostream>
+#include <sys/stat.h>
+
+Mappa::Mappa()
+{
+	printf("mappa()\n");
+	mappa = mappa_create(NULL);
+	if(!mappa)
+		printf("Mappa() error return from mappa_create()\n");
+}
+
+void target_track_vol(uint32_t target_id, float value, void *token,
+		      uint32_t token_size, void *userdata)
+{
+	uint32_t *track = (uint32_t *)token;
+	EventTrackVol e(*track, value);
+	writeToDspRingbuffer( &e );
+}
+
+void target_track_send(uint32_t target_id, float value, void *token,
+		       uint32_t token_size, void *userdata)
+{
+	uint32_t *track = (uint32_t *)token;
+	EventTrackSend e(*track, SEND_POSTFADER, value);
+	writeToDspRingbuffer( &e );
+}
+
+int Mappa::register_targets()
+{
+	/* TODO: register some targets here */
+	printf("registering targets now\n");
+
+	struct mappa_target_t t = {0};
+	t.userdata = this;
+
+	const char *track_targets[] = {
+		"vol",
+		"send",
+	};
+	mappa_target_float_func funcs[] = {
+		target_track_vol,
+		target_track_send,
+	};
+
+	for(int j = 0; j < 2; j++) {
+		for(int i = 0; i < NTRACKS; i++) {
+			char buf[32];
+			snprintf(buf, sizeof(buf), "luppp:track_%d_%s", i,
+				 track_targets[j]);
+			t.name = buf;
+			t.func = funcs[j];
+			/* add a target with the "token payload" as the value of
+			 * i. This will be passed back when the callback is invoked.
+			 * This allows the callback to easily identify which track
+			 * it is that this target is pointing to */
+			int32_t ret = mappa_target_add(mappa, &t, 0,
+						       &i, sizeof(int));
+			if(ret)
+				printf("error registering target %s\n", t.name);
+		}
+	}
+
+	int32_t ret = mappa_load_bindings(mappa, "z1_mappa.ini");
+	printf("load bindings ret = %d\n", ret);
+
+	return 0;
+}
+
+int Mappa::iter()
+{
+	mappa_iter(mappa);
+	return 0;
+}
+
+Mappa::~Mappa()
+{
+	mappa_destroy(mappa);
+}
+

--- a/src/mappa.hxx
+++ b/src/mappa.hxx
@@ -1,0 +1,48 @@
+/*
+ * Author: Harry van Haaren 2018
+ *         harryhaaren@gmail.com
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#ifndef LUPPP_MAPPA_H
+#define LUPPP_MAPPA_H
+
+#include <ctlra/ctlra.h>
+#include <ctlra/event.h>
+#include <ctlra/mappa.h>
+
+/** This is the Mappa implementation for Luppp. */
+class Mappa
+{
+public:
+	Mappa();
+	virtual ~Mappa();
+
+	/* initialize the luppp software targets which can be modified
+	 * by Mappa. This allows the user to create mappings from their
+	 * hardware to these Luppp control knobs. */
+	int register_targets();
+
+	/* iterate the mappings - poll devices and handle I/O. Performs
+	 * the target callbacks in this thread */
+	int iter();
+
+private:
+	struct mappa_t *mappa;
+};
+
+#endif // LUPPP_MAPPA_H
+

--- a/src/meson.build
+++ b/src/meson.build
@@ -23,6 +23,7 @@ luppp_src = files(
   'looperclip.cxx',
   'looper.cxx',
   'main.cxx',
+  'mappa.cxx',
   'metronome.cxx',
   'timemanager.cxx',
   'trackoutput.cxx'


### PR DESCRIPTION
This commit is the first commit to support Mappa,
the "mapping" solution from the Ctlra project.

The code here implements two targets as callback
functions, making use of the Mappa "token" when registering
a target. The track-id is stored in the token, allowing easy
identification of the software parameter to tweak.

The main UI thread polls the mappa library, which internally
handles all Ctlra APIs. The application sees its callbacks
being called when a control surface is moved. The callbacks
are invoked in the same thread as that which calls mappa_iter().

The mapping from control-surface to software-target is done using
a simple .ini file, which the user supplies. The format is still
in flux, but the basic structure is not expected to change.

The user provides multiple "layers" of mappings, and Mappa provides
a mechanism to switch between these layers on the fly. This enables
complex multi-layered controller setups, without any application
logic complexity.

Note that the latest commit from the Mapping PR of Ctlra is required
in order to get access to mappa.h, see details of PR here:
https://github.com/openAVproductions/openAV-Ctlra/pull/87

This resolves the following Ctlra issue to do real testing with Luppp:
https://github.com/openAVproductions/openAV-Ctlra/issues/90

Signed-off-by: Harry van Haaren <harryhaaren@gmail.com>