### PR TITLE
Smoothing for discrete controls

### DIFF
--- a/src/config.hxx
+++ b/src/config.hxx
@@ -70,8 +70,7 @@
 #define LUPPP_RETURN_ERROR    2
 
 // Smoothing value
-#define SMOOTHING_CONST 0.05
-
+#define SMOOTHING_CONST 0.005
 
 ///     debug.hxx for printing convienience
 #include "debug.hxx"

--- a/src/jack.cxx
+++ b/src/jack.cxx
@@ -203,6 +203,7 @@ Jack::Jack( std::string name ) :
 	inputToMixEnable  = false;
 	inputToSendEnable = false;
 	inputToKeyEnable  = false;
+	inputToKeyEnableLag = 0;
 	inputToMixVol     = 0.f;
 	inputToMixVolLag  = 0.f;
 	inputToSendVol    = 0.f;
@@ -547,6 +548,8 @@ void Jack::processFrames(int nframes)
 		returnVolLag += SMOOTHING_CONST * (returnVol - returnVolLag);
 		inputVolLag += SMOOTHING_CONST * (inputVol - inputVolLag);
 
+		inputToKeyEnableLag += SMOOTHING_CONST * (inputToKeyEnable - inputToKeyEnableLag);
+
 		float inputL = buffers.audio[Buffers::MASTER_INPUT_L][i] * inputVolLag;
 		float inputR = buffers.audio[Buffers::MASTER_INPUT_R][i] * inputVolLag;
 
@@ -568,10 +571,10 @@ void Jack::processFrames(int nframes)
 				buffers.audio[Buffers::SEND_R][i] += inputR * inputToSendVolLag * inputToMixVolLag;
 			}
 		}
-		if ( inputToKeyEnable ) {
-			buffers.audio[Buffers::SIDECHAIN_KEY_L][i] += inputL;
-			buffers.audio[Buffers::SIDECHAIN_KEY_R][i] += inputR;
-		}
+		
+		buffers.audio[Buffers::SIDECHAIN_KEY_L][i] += inputL * inputToKeyEnableLag;
+		buffers.audio[Buffers::SIDECHAIN_KEY_R][i] += inputR * inputToKeyEnableLag;
+		
 
 		buffers.audio[Buffers::SIDECHAIN_SIGNAL_L][i] += inputL * inputToXSideVolLag;
 		buffers.audio[Buffers::SIDECHAIN_SIGNAL_R][i] += inputR * inputToXSideVolLag;

--- a/src/jack.cxx
+++ b/src/jack.cxx
@@ -208,6 +208,7 @@ Jack::Jack( std::string name ) :
 	inputToSendVol    = 0.f;
 	inputToSendVolLag = 0.f;
 	inputToXSideVol   = 0.f;
+	inputToXSideVolLag = 0.f;
 
 	/// prepare internal buffers
 	buffers.audio[Buffers::SEND_L]            = new float[ buffers.nframes ];
@@ -541,6 +542,7 @@ void Jack::processFrames(int nframes)
 		// compute *lags für smoothing
 		inputToMixVolLag += SMOOTHING_CONST * (inputToMixVol - inputToMixVolLag);
 		inputToSendVolLag += SMOOTHING_CONST * (inputToSendVol - inputToSendVolLag);
+		inputToXSideVolLag += SMOOTHING_CONST * (inputToXSideVol - inputToXSideVolLag);
 
 		float inputL = buffers.audio[Buffers::MASTER_INPUT_L][i] * inputVol;
 		float inputR = buffers.audio[Buffers::MASTER_INPUT_R][i] * inputVol;
@@ -552,8 +554,8 @@ void Jack::processFrames(int nframes)
 
 		if ( inputToMixEnable ) {
 			// if sending to mix, scale by volume *and* by XSide send
-			float tmpL = inputL * inputToMixVolLag * (1-inputToXSideVol);
-			float tmpR = inputR * inputToMixVolLag * (1-inputToXSideVol);
+			float tmpL = inputL * inputToMixVolLag * (1-inputToXSideVolLag);
+			float tmpR = inputR * inputToMixVolLag * (1-inputToXSideVolLag);
 			L += tmpL;
 			R += tmpR;
 			
@@ -568,8 +570,8 @@ void Jack::processFrames(int nframes)
 			buffers.audio[Buffers::SIDECHAIN_KEY_R][i] += inputR;
 		}
 
-		buffers.audio[Buffers::SIDECHAIN_SIGNAL_L][i] += inputL * inputToXSideVol;
-		buffers.audio[Buffers::SIDECHAIN_SIGNAL_R][i] += inputR * inputToXSideVol;
+		buffers.audio[Buffers::SIDECHAIN_SIGNAL_L][i] += inputL * inputToXSideVolLag;
+		buffers.audio[Buffers::SIDECHAIN_SIGNAL_R][i] += inputR * inputToXSideVolLag;
 
 		//compute master volume lag;
 		masterVolLag += SMOOTHING_CONST * (masterVol - masterVolLag);

--- a/src/jack.cxx
+++ b/src/jack.cxx
@@ -206,6 +206,7 @@ Jack::Jack( std::string name ) :
 	inputToMixVol     = 0.f;
 	inputToMixVolLag  = 0.f;
 	inputToSendVol    = 0.f;
+	inputToSendVolLag = 0.f;
 	inputToXSideVol   = 0.f;
 
 	/// prepare internal buffers
@@ -539,6 +540,7 @@ void Jack::processFrames(int nframes)
 	for(unsigned int i = 0; i < nframes; i++) {
 		// compute *lags für smoothing
 		inputToMixVolLag += SMOOTHING_CONST * (inputToMixVol - inputToMixVolLag);
+		inputToSendVolLag += SMOOTHING_CONST * (inputToSendVol - inputToSendVolLag);
 
 		float inputL = buffers.audio[Buffers::MASTER_INPUT_L][i] * inputVol;
 		float inputR = buffers.audio[Buffers::MASTER_INPUT_R][i] * inputVol;
@@ -557,8 +559,8 @@ void Jack::processFrames(int nframes)
 			
 			if ( inputToSendEnable ) {
 				// post-mix-send amount: hence * inputToMixVol
-				buffers.audio[Buffers::SEND_L][i] += inputL * inputToSendVol * inputToMixVolLag;
-				buffers.audio[Buffers::SEND_R][i] += inputR * inputToSendVol * inputToMixVolLag;
+				buffers.audio[Buffers::SEND_L][i] += inputL * inputToSendVolLag * inputToMixVolLag;
+				buffers.audio[Buffers::SEND_R][i] += inputR * inputToSendVolLag * inputToMixVolLag;
 			}
 		}
 		if ( inputToKeyEnable ) {

--- a/src/jack.cxx
+++ b/src/jack.cxx
@@ -199,7 +199,7 @@ Jack::Jack( std::string name ) :
 
 
 	returnVol = 1.0f;
-
+	returnVolLag = 1.0f;
 	inputToMixEnable  = false;
 	inputToSendEnable = false;
 	inputToKeyEnable  = false;
@@ -543,6 +543,7 @@ void Jack::processFrames(int nframes)
 		inputToMixVolLag += SMOOTHING_CONST * (inputToMixVol - inputToMixVolLag);
 		inputToSendVolLag += SMOOTHING_CONST * (inputToSendVol - inputToSendVolLag);
 		inputToXSideVolLag += SMOOTHING_CONST * (inputToXSideVol - inputToXSideVolLag);
+		returnVolLag += SMOOTHING_CONST * (returnVol - returnVolLag);
 
 		float inputL = buffers.audio[Buffers::MASTER_INPUT_L][i] * inputVol;
 		float inputR = buffers.audio[Buffers::MASTER_INPUT_R][i] * inputVol;
@@ -576,8 +577,8 @@ void Jack::processFrames(int nframes)
 		//compute master volume lag;
 		masterVolLag += SMOOTHING_CONST * (masterVol - masterVolLag);
 		/// mixdown returns into master buffers
-		buffers.audio[Buffers::JACK_MASTER_OUT_L][i] = (L + returnL*returnVol) * masterVolLag;
-		buffers.audio[Buffers::JACK_MASTER_OUT_R][i] = (R + returnR*returnVol) * masterVolLag;
+		buffers.audio[Buffers::JACK_MASTER_OUT_L][i] = (L + returnL*returnVolLag) * masterVolLag;
+		buffers.audio[Buffers::JACK_MASTER_OUT_R][i] = (R + returnR*returnVolLag) * masterVolLag;
 
 		/// write SEND content to JACK port
 		buffers.audio[Buffers::JACK_SEND_OUT_L][i] = buffers.audio[Buffers::SEND_L][i];

--- a/src/jack.cxx
+++ b/src/jack.cxx
@@ -78,15 +78,14 @@ Jack::Jack( std::string name ) :
 	client( jack_client_open ( name.c_str(), JackNullOption, 0, 0 ) ),
 	state( new State() ),
 	controllerUpdater( new ControllerUpdater() ),
-	clientActive(false),
-	smoothing_value(SMOOTHING_CONST * (44100.f / samplerate))
+	clientActive(false)
 {
 	jack = this;
 	lastnframes=0;
 	samplerate = jack_get_sample_rate( client );
 
 	// calculate smoothing value for current sample rate
-	//smoothing_value = SMOOTHING_CONST * (44100.f / samplerate);
+	smoothing_value = SMOOTHING_CONST * (44100.f / samplerate);
 
 	// construct Observer classes here, not in the initializer list as the Jack*
 	// will be 0x0 until then.

--- a/src/jack.cxx
+++ b/src/jack.cxx
@@ -266,6 +266,7 @@ Jack::Jack( std::string name ) :
 
 	/// setup DSP instances
 	inputVol = 1.0f;
+	inputVolLag = 1.0f;
 	masterVol = 0.75f;
 	masterVolLag =0.75f;
 
@@ -544,9 +545,10 @@ void Jack::processFrames(int nframes)
 		inputToSendVolLag += SMOOTHING_CONST * (inputToSendVol - inputToSendVolLag);
 		inputToXSideVolLag += SMOOTHING_CONST * (inputToXSideVol - inputToXSideVolLag);
 		returnVolLag += SMOOTHING_CONST * (returnVol - returnVolLag);
+		inputVolLag += SMOOTHING_CONST * (inputVol - inputVolLag);
 
-		float inputL = buffers.audio[Buffers::MASTER_INPUT_L][i] * inputVol;
-		float inputR = buffers.audio[Buffers::MASTER_INPUT_R][i] * inputVol;
+		float inputL = buffers.audio[Buffers::MASTER_INPUT_L][i] * inputVolLag;
+		float inputR = buffers.audio[Buffers::MASTER_INPUT_R][i] * inputVolLag;
 
 		float L    = buffers.audio[Buffers::MASTER_OUT_L][i];
 		float R    = buffers.audio[Buffers::MASTER_OUT_R][i];
@@ -598,7 +600,7 @@ void Jack::processFrames(int nframes)
 		// instead of scaling whole buffer, just scale output by vol
 		EventTrackSignalLevel e(-1, masterMeter->getLeftDB(), masterMeter->getRightDB() );
 		writeToGuiRingbuffer( &e );
-		EventTrackSignalLevel e2(-2, inputMeter->getLeftDB() * inputVol, inputMeter->getRightDB() * inputVol );
+		EventTrackSignalLevel e2(-2, inputMeter->getLeftDB() * inputVolLag, inputMeter->getRightDB() * inputVol );
 		writeToGuiRingbuffer( &e2 );
 
 		uiUpdateCounter = 0;

--- a/src/jack.hxx
+++ b/src/jack.hxx
@@ -179,6 +179,8 @@ private:
 	float inputToXSideVolLag;
 
 	bool  inputToKeyEnable;
+	float inputToKeyEnableLag;
+	
 	bool  inputToMixEnable;
 	bool  inputToSendEnable;
 

--- a/src/jack.hxx
+++ b/src/jack.hxx
@@ -136,6 +136,8 @@ public:
 	int bindingActive;
 
 	JackSendReturn *getJackSendReturn(int t);
+
+	const float smoothing_value;
 private:
 	int                 lastnframes;
 	jack_client_t*      client;

--- a/src/jack.hxx
+++ b/src/jack.hxx
@@ -157,10 +157,12 @@ private:
 	// FX
 	DBMeter* inputMeter;
 	DBMeter* masterMeter;
-
-	float inputVol;
-	/// _toMasterLag is a volume that lags behind _toMaster when setMaster() is called
+	
+	/// *Lag are values that lag behind their corresponding value
 	/// This prohibits audible jumps when rapidly changing the volume
+	float inputVol;
+	float inputVolLag;
+	
 	float masterVol;
 	float masterVolLag;
 

--- a/src/jack.hxx
+++ b/src/jack.hxx
@@ -138,7 +138,7 @@ public:
 	JackSendReturn *getJackSendReturn(int t);
 private:
 	int                 lastnframes;
-	jack_client_t* client;
+	jack_client_t*      client;
 
 	Buffers             buffers;
 	TimeManager*        timeManager;
@@ -166,6 +166,8 @@ private:
 	float returnVol;
 
 	float inputToMixVol;
+	float inputToMixVolLag;
+
 	float inputToSendVol;
 	float inputToXSideVol;
 

--- a/src/jack.hxx
+++ b/src/jack.hxx
@@ -163,7 +163,9 @@ private:
 	/// This prohibits audible jumps when rapidly changing the volume
 	float masterVol;
 	float masterVolLag;
+
 	float returnVol;
+	float returnVolLag;
 
 	float inputToMixVol;
 	float inputToMixVolLag;

--- a/src/jack.hxx
+++ b/src/jack.hxx
@@ -185,6 +185,7 @@ private:
 	float inputToMixEnableLag;
 
 	bool  inputToSendEnable;
+	float inputToSendEnableLag;
 
 	// JACK member variables
 	bool clientActive;

--- a/src/jack.hxx
+++ b/src/jack.hxx
@@ -170,8 +170,9 @@ private:
 
 	float inputToSendVol;
 	float inputToSendVolLag;
-	
+
 	float inputToXSideVol;
+	float inputToXSideVolLag;
 
 	bool  inputToKeyEnable;
 	bool  inputToMixEnable;

--- a/src/jack.hxx
+++ b/src/jack.hxx
@@ -180,8 +180,10 @@ private:
 
 	bool  inputToKeyEnable;
 	float inputToKeyEnableLag;
-	
+
 	bool  inputToMixEnable;
+	float inputToMixEnableLag;
+
 	bool  inputToSendEnable;
 
 	// JACK member variables

--- a/src/jack.hxx
+++ b/src/jack.hxx
@@ -169,6 +169,8 @@ private:
 	float inputToMixVolLag;
 
 	float inputToSendVol;
+	float inputToSendVolLag;
+	
 	float inputToXSideVol;
 
 	bool  inputToKeyEnable;

--- a/src/jack.hxx
+++ b/src/jack.hxx
@@ -137,7 +137,7 @@ public:
 
 	JackSendReturn *getJackSendReturn(int t);
 
-	const float smoothing_value;
+	float smoothing_value;
 private:
 	int                 lastnframes;
 	jack_client_t*      client;

--- a/src/jacksendreturn.cxx
+++ b/src/jacksendreturn.cxx
@@ -53,12 +53,12 @@ void JackSendReturn::process(unsigned int nframes, Buffers *buffers)
 	}
 
 	for(int i=0; i<nframes; i++) {
-		_sendVolLag += SMOOTHING_CONST * (_sendVol - _sendVolLag);
+		_sendVolLag += jack->smoothing_value * (_sendVol - _sendVolLag);
 
 		sendL[i] = _sendVolLag * sendtrackL[i];
 		sendR[i] = _sendVolLag * sendtrackR[i];
 
-		_activeLag += SMOOTHING_CONST * (float(_active) - _activeLag);
+		_activeLag += jack->smoothing_value * (float(_active) - _activeLag);
 
 		rettrackL[i] = retL[i] * _activeLag + sendtrackL[i] * std::fabs(_activeLag - 1);
 		rettrackR[i] = retR[i] * _activeLag + sendtrackR[i] * std::fabs(_activeLag - 1);

--- a/src/jacksendreturn.cxx
+++ b/src/jacksendreturn.cxx
@@ -52,8 +52,10 @@ void JackSendReturn::process(unsigned int nframes, Buffers *buffers)
 	}
 
 	for(int i=0; i<nframes; i++) {
-		sendL[i]=_sendVol*sendtrackL[i];
-		sendR[i]=_sendVol*sendtrackR[i];
+		_sendVolLag += SMOOTHING_CONST * (_sendVol - _sendVolLag);
+
+		sendL[i] = _sendVolLag * sendtrackL[i];
+		sendR[i] = _sendVolLag * sendtrackR[i];
 	}
 
 	if(offset)

--- a/src/jacksendreturn.cxx
+++ b/src/jacksendreturn.cxx
@@ -4,28 +4,28 @@
 #include <assert.h>
 extern Jack* jack;
 JackSendReturn::JackSendReturn(int trackid, AudioProcessor *prev, jack_client_t *client)
-	:m_trackid(trackid), m_previousProcessor(prev), m_sendvol(1.0f)
+	:_trackId(trackid), _previousProcessor(prev), _sendVol(1.0f)
 {
 	char name[50];
 	int trackid_human = trackid + 1;
 	sprintf(name, "Send_track_%d_l\n",trackid_human);
-	m_sendport_l=jack_port_register(client,name,JACK_DEFAULT_AUDIO_TYPE,JackPortIsOutput,0);
+	_sendPortL=jack_port_register(client,name,JACK_DEFAULT_AUDIO_TYPE,JackPortIsOutput,0);
 	sprintf(name, "Send_track_%d_r\n",trackid_human);
-	m_sendport_r=jack_port_register(client,name,JACK_DEFAULT_AUDIO_TYPE,JackPortIsOutput,0);
+	_sendPortR=jack_port_register(client,name,JACK_DEFAULT_AUDIO_TYPE,JackPortIsOutput,0);
 	sprintf(name, "Return_track_%d_l\n",trackid_human);
-	m_returnport_l=jack_port_register(client,name,JACK_DEFAULT_AUDIO_TYPE,JackPortIsInput,0);
+	_returnPortL=jack_port_register(client,name,JACK_DEFAULT_AUDIO_TYPE,JackPortIsInput,0);
 	sprintf(name, "Return_track_%d_r\n",trackid_human);
-	m_returnport_r=jack_port_register(client,name,JACK_DEFAULT_AUDIO_TYPE,JackPortIsInput,0);
-	m_active=false;
-	m_counter=0;
+	_returnPortR=jack_port_register(client,name,JACK_DEFAULT_AUDIO_TYPE,JackPortIsInput,0);
+	_active=false;
+	_counter=0;
 }
 
 void JackSendReturn::process(unsigned int nframes, Buffers *buffers)
 {
 	// index = first-track + (track * channels)
-	int trackoffset = m_trackid * NCHANNELS;
+	int trackoffset = _trackId * NCHANNELS;
 	//Reset send buffer
-	int offset=m_counter%(buffers->nframes);
+	int offset=_counter%(buffers->nframes);
 	float* sendtrackL=&(buffers->audio[Buffers::SEND_TRACK_0_L + trackoffset][0]);
 	float* sendtrackR=&(buffers->audio[Buffers::SEND_TRACK_0_R + trackoffset][0]);
 
@@ -37,12 +37,12 @@ void JackSendReturn::process(unsigned int nframes, Buffers *buffers)
 	memset(sendtrackR,0,nframes*sizeof(float));
 
 	//Process previous AudioProcessor
-	m_previousProcessor->process(nframes,buffers);
+	_previousProcessor->process(nframes,buffers);
 
-	float* sendL=(float*)jack_port_get_buffer(m_sendport_l,  (jack_nframes_t)(buffers->nframes));
-	float* sendR=(float*)jack_port_get_buffer(m_sendport_r,  (jack_nframes_t)(buffers->nframes));
-	float* retL =(float*)jack_port_get_buffer(m_returnport_l,(jack_nframes_t)(buffers->nframes));
-	float* retR =(float*)jack_port_get_buffer(m_returnport_r,(jack_nframes_t)(buffers->nframes));
+	float* sendL=(float*)jack_port_get_buffer(_sendPortL,  (jack_nframes_t)(buffers->nframes));
+	float* sendR=(float*)jack_port_get_buffer(_sendPortR,  (jack_nframes_t)(buffers->nframes));
+	float* retL =(float*)jack_port_get_buffer(_returnPortL,(jack_nframes_t)(buffers->nframes));
+	float* retR =(float*)jack_port_get_buffer(_returnPortR,(jack_nframes_t)(buffers->nframes));
 
 	if(offset) {
 		sendL+=offset;
@@ -52,14 +52,14 @@ void JackSendReturn::process(unsigned int nframes, Buffers *buffers)
 	}
 
 	for(int i=0; i<nframes; i++) {
-		sendL[i]=m_sendvol*sendtrackL[i];
-		sendR[i]=m_sendvol*sendtrackR[i];
+		sendL[i]=_sendVol*sendtrackL[i];
+		sendR[i]=_sendVol*sendtrackR[i];
 	}
 
 	if(offset)
 		assert(offset+nframes==buffers->nframes);
 
-	if(m_active) {
+	if(_active) {
 		memcpy(rettrackL,retL,nframes*sizeof(float));
 		memcpy(rettrackR,retR,nframes*sizeof(float));
 	}
@@ -67,16 +67,16 @@ void JackSendReturn::process(unsigned int nframes, Buffers *buffers)
 		memcpy(rettrackL, sendtrackL,nframes*sizeof(float));
 		memcpy(rettrackR, sendtrackR,nframes*sizeof(float));
 	}
-	m_counter+=nframes;
+	_counter+=nframes;
 
 }
 
 void JackSendReturn::activate(bool act)
 {
-	m_active=act;
+	_active=act;
 }
 
 void JackSendReturn::sendVolume(float vol)
 {
-	m_sendvol=vol;
+	_sendVol=vol;
 }

--- a/src/jacksendreturn.hxx
+++ b/src/jacksendreturn.hxx
@@ -45,6 +45,8 @@ public:
 private:
 	bool _active;
 	float _sendVol;
+	float _sendVolLag;
+
 	jack_port_t* _sendPortL;
 	jack_port_t* _sendPortR;
 	jack_port_t* _returnPortL;

--- a/src/jacksendreturn.hxx
+++ b/src/jacksendreturn.hxx
@@ -37,21 +37,21 @@ public:
 	//The process callback
 	virtual void process(unsigned int nframes, Buffers* buffers);
 
-	//Activate the return chain. When m_active=true then Buffers::RETURN_TRACK_0+m_trackid gets the data
+	//Activate the return chain. When _active=true then Buffers::RETURN_TRACK_0+_trackid gets the data
 	//from the return port. The send port always send the incoming data
 	void activate(bool act);
 	void sendVolume(float vol);
 
 private:
-	bool m_active;
-	float m_sendvol;
-	jack_port_t* m_sendport_l;
-	jack_port_t* m_sendport_r;
-	jack_port_t* m_returnport_l;
-	jack_port_t* m_returnport_r;
-	int m_trackid;
-	AudioProcessor* m_previousProcessor;
-	int m_counter;
+	bool _active;
+	float _sendVol;
+	jack_port_t* _sendPortL;
+	jack_port_t* _sendPortR;
+	jack_port_t* _returnPortL;
+	jack_port_t* _returnPortR;
+	int _trackId;
+	AudioProcessor* _previousProcessor;
+	int _counter;
 };
 
 #endif

--- a/src/jacksendreturn.hxx
+++ b/src/jacksendreturn.hxx
@@ -44,6 +44,8 @@ public:
 
 private:
 	bool _active;
+	float _activeLag;
+	
 	float _sendVol;
 	float _sendVolLag;
 

--- a/src/trackoutput.cxx
+++ b/src/trackoutput.cxx
@@ -52,8 +52,10 @@ TrackOutput::TrackOutput(int t, AudioProcessor* ap) :
 
 	_toPostfaderActive        = 0;
 	_toPostfaderActiveLag 	  = 0;
-	
+
 	_toKeyActive     = 0;
+	_toKeyActiveLag  = 0;
+
 	_toXSideActive = true;
 }
 
@@ -190,7 +192,8 @@ void TrackOutput::process(unsigned int nframes, Buffers* buffers)
 
 		// compute discrete lag values
 		_toPostfaderActiveLag += SMOOTHING_CONST * (float(_toPostfaderActive) - _toPostfaderActiveLag);
-
+		_toKeyActiveLag       += SMOOTHING_CONST * (float(_toKeyActive) - _toKeyActiveLag);
+		
 		// * master for "post-fader" sends
 		float tmpL = trackBufferL[i];
 		float tmpR = trackBufferR[i]; 
@@ -212,11 +215,8 @@ void TrackOutput::process(unsigned int nframes, Buffers* buffers)
 		}
 
 		// turning down an element in the mix should *NOT* influence sidechaining
-		if ( _toKeyActive ) {
-			sidechainL[i]     += tmpL;
-			sidechainR[i]     += tmpR;
-		}
-
+		sidechainL[i]     += tmpL * _toKeyActiveLag;
+		sidechainR[i]     += tmpR * _toKeyActiveLag;
 	}
 }
 

--- a/src/trackoutput.cxx
+++ b/src/trackoutput.cxx
@@ -136,7 +136,7 @@ void TrackOutput::process(unsigned int nframes, Buffers* buffers)
 	int trackoffset = track * NCHANNELS;
 
 	//compute master volume lag;
-	_toMasterLag += SMOOTHING_CONST * (_toMaster - _toMasterLag);
+	_toMasterLag += jack->smoothing_value * (_toMaster - _toMasterLag);
 
 	// get & zero track buffer
 	float* trackBufferL = buffers->audio[Buffers::RETURN_TRACK_0_L + trackoffset];
@@ -178,21 +178,21 @@ void TrackOutput::process(unsigned int nframes, Buffers* buffers)
 	for(unsigned int i = 0; i < nframes; i++) {
 
 		//compute master volume lag;
-		_toMasterLag += SMOOTHING_CONST * (_toMaster - _toMasterLag);
+		_toMasterLag += jack->smoothing_value * (_toMaster - _toMasterLag);
 
 		// compute pan lag:
-		_panLLag += SMOOTHING_CONST * (_panL - _panLLag);
-		_panRLag += SMOOTHING_CONST * (_panR - _panRLag);
+		_panLLag += jack->smoothing_value * (_panL - _panLLag);
+		_panRLag += jack->smoothing_value * (_panR - _panRLag);
 
 		// compute send volume lag:
-		_toSendLag += SMOOTHING_CONST * (_toSend - _toSendLag);
+		_toSendLag += jack->smoothing_value * (_toSend - _toSendLag);
 
 		// compute sidechain signal lag
-		_toPostSidechainLag += SMOOTHING_CONST * (_toPostSidechain - _toPostSidechainLag);
+		_toPostSidechainLag += jack->smoothing_value * (_toPostSidechain - _toPostSidechainLag);
 
 		// compute discrete lag values
-		_toPostfaderActiveLag += SMOOTHING_CONST * (float(_toPostfaderActive) - _toPostfaderActiveLag);
-		_toKeyActiveLag       += SMOOTHING_CONST * (float(_toKeyActive) - _toKeyActiveLag);
+		_toPostfaderActiveLag += jack->smoothing_value * (float(_toPostfaderActive) - _toPostfaderActiveLag);
+		_toKeyActiveLag       += jack->smoothing_value * (float(_toKeyActive) - _toKeyActiveLag);
 		
 		// * master for "post-fader" sends
 		float tmpL = trackBufferL[i];

--- a/src/trackoutput.hxx
+++ b/src/trackoutput.hxx
@@ -80,6 +80,8 @@ private:
 	float _toPostSidechainLag;
 
 	bool _toPostfaderActive;
+	float _toPostfaderActiveLag;
+
 	bool _toKeyActive;
 	bool _toXSideActive;
 

--- a/src/trackoutput.hxx
+++ b/src/trackoutput.hxx
@@ -83,6 +83,8 @@ private:
 	float _toPostfaderActiveLag;
 
 	bool _toKeyActive;
+	float _toKeyActiveLag;
+
 	bool _toXSideActive;
 
 	/// Pointer to "previous" processor: the graph is backwards


### PR DESCRIPTION
(+ one continuous i forgot :upside_down_face: )

This is the last PR for smoothing out all controls in Luppp. Until now this is only implemented for the FX-Buttons. So todo is:

- Snd-Buttons
- Key-Buttons (usually no one should hear this signal but for sure)
- Input Mix-Button

But i wont make this today and wanted to upload to get early feedback. 