### PR TITLE
prevent scene names being cleared on scene launch

### DIFF
--- a/src/avtk/clipselector.cxx
+++ b/src/avtk/clipselector.cxx
@@ -72,9 +72,6 @@ void ClipSelector::setState( int clipNum, GridLogic::State s )
 	//cout << "ClipSelector::setState() t = " << ID << " clipNum = " << clipNum << "  state = " << s << endl;
 #endif
 	clips[clipNum].setState( s );
-	if ( s == GridLogic::STATE_EMPTY ) {
-		clips[clipNum].setName("");
-	}
 
 	redraw();
 }

--- a/src/eventhandlergui.cxx
+++ b/src/eventhandlergui.cxx
@@ -249,9 +249,11 @@ void handleGuiEvents()
 					gui->getTrack(ev.track)->getClipSelector()->setState( ev.scene, ev.state );
 					if ( ev.state == GridLogic::STATE_RECORDING )
 						gui->getTrack(ev.track)->getRadialStatus()->recording( true );
-					else if ( ev.state == GridLogic::STATE_EMPTY )
+					else if ( ev.state == GridLogic::STATE_EMPTY ) {
 						// reset clip name if clip gets cleared
-						gui->getTrack(ev.track)->getClipSelector()->clips[ ev.scene ].setName(""); 
+						gui->getTrack(ev.track)->getClipSelector()->clips[ ev.scene ].setName("");
+						gui->getTrack(ev.track)->getRadialStatus()->recording(false);
+					}
 					else
 						gui->getTrack(ev.track)->getRadialStatus()->recording( false );
 				}

--- a/src/eventhandlergui.cxx
+++ b/src/eventhandlergui.cxx
@@ -249,6 +249,9 @@ void handleGuiEvents()
 					gui->getTrack(ev.track)->getClipSelector()->setState( ev.scene, ev.state );
 					if ( ev.state == GridLogic::STATE_RECORDING )
 						gui->getTrack(ev.track)->getRadialStatus()->recording( true );
+					else if ( ev.state == GridLogic::STATE_EMPTY )
+						// reset clip name if clip gets cleared
+						gui->getTrack(ev.track)->getClipSelector()->clips[ ev.scene ].setName(""); 
 					else
 						gui->getTrack(ev.track)->getRadialStatus()->recording( false );
 				}


### PR DESCRIPTION
@harryhaaren This is a proposal to fix the issue we talked about last night. The idea came to me this morning, I don't know if this is a sane solution. So please have a look and decide, if this seems to be okay. 

In general it would be a good idea to redesign how the GUI is build in this aspect, handling scenes and clips with the same class is obviously possible but also is kind of hacky.