### PR TITLE
dial: fix unitialized variable

### DIFF
--- a/src/avtk/avtk_dial.h
+++ b/src/avtk/avtk_dial.h
@@ -45,6 +45,8 @@ public:
 		mouseClicked = false;
 
 		highlight = false;
+
+		pan_style = 0;
 	}
 
 	bool highlight;


### PR DESCRIPTION
Before this the pan_style value was not initialized,
meaning that the dial could (very rarely) appear as
a pan style dial when it should not be. Thanks valgrind :)

Signed-off-by: Harry van Haaren <harryhaaren@gmail.com>