### PR TITLE
timemanager: error check tempos from "Use Tempo"

### DIFF
--- a/src/goptions.cxx
+++ b/src/goptions.cxx
@@ -82,7 +82,8 @@ static void updateLinkCB(Fl_Widget* w, void* data)
 	str << l;
 
 	int ret = system( str.str().c_str() );
-	/* if it fails it fails.. */
+	/* if it fails it fails... (void) to mute clang warning */
+	(void)ret;
 }
 
 static void writeBindEnable(Fl_Widget* w, void* data)

--- a/src/timemanager.cxx
+++ b/src/timemanager.cxx
@@ -110,7 +110,8 @@ void TimeManager::setFpb(double f)
 	int bpm = ( samplerate * 60) / f;
 
 	char buffer [50];
-	sprintf (buffer, "TM, setFpb() %i, bpm = %i", int(f), int(bpm) );
+	snprintf(buffer, sizeof(buffer), "TM, setFpb() %i, bpm = %i",
+		  int(f), int(bpm) );
 	EventGuiPrint e( buffer );
 	writeToGuiRingbuffer( &e );
 
@@ -153,14 +154,16 @@ void TimeManager::tap()
 
 		if( average < 13000 ) {
 			char buffer [50];
-			sprintf (buffer, "TM, tap() average too slow! quitting");
+			snprintf(buffer, sizeof(buffer),
+				 "TM, tap() average too slow! quitting");
 			EventGuiPrint e( buffer );
 			writeToGuiRingbuffer( &e );
 			return;
 		}
 
 		char buffer [50];
-		sprintf (buffer, "TM, tap() average = %i", average );
+		snprintf(buffer, sizeof(buffer), "TM, tap() average = %i",
+			 average);
 		EventGuiPrint e( buffer );
 		writeToGuiRingbuffer( &e );
 
@@ -217,13 +220,16 @@ void TimeManager::process(Buffers* buffers)
 
 		if ( before < nframes && after <= nframes && before + after == nframes ) {
 			char buffer [50];
-//      sprintf (buffer, "Timing OK: before %i, after %i, b+a %i",  before, after, before+after );
+//      snprintf(buffer, sizeof(buffer), "Timing OK: before %i, after %i, b+a %i",
+//               before, after, before+after );
 //      EventGuiPrint e2( buffer );
 //      writeToGuiRingbuffer( &e2 );
 
 		} else {
 			char buffer [50];
-			sprintf (buffer, "Timing Error: before: %i, after %i", before, after );
+			snprintf(buffer, sizeof(buffer),
+				 "Timing Error: before: %i, after %i",
+				 before, after );
 			EventGuiPrint e2( buffer );
 			writeToGuiRingbuffer( &e2 );
 		}

--- a/src/timemanager.cxx
+++ b/src/timemanager.cxx
@@ -86,6 +86,16 @@ void TimeManager::queueBpmChangeZeroOne(float b)
 
 void TimeManager::queueFpbChange( double f )
 {
+	float bpm = (samplerate * 60.f) / f;
+	if(bpm < MIN_TEMPO || bpm > MAX_TEMPO) {
+		char buffer[128];
+		snprintf(buffer, sizeof(buffer), "drop TM::qfpb() %d bpm = %d",
+			 (int)f, (int)bpm);
+		EventGuiPrint e( buffer );
+		writeToGuiRingbuffer( &e );
+		return;
+	}
+
 	_bpmChangeQueued = true;
 	_nextFpb = f;
 }


### PR DESCRIPTION
This commit adds a bpm conversion from the fpb to set the
tempo to, and then limits the values to the range as set
in config.hxx. A message is safely printed to the console
when a message is dropped. Fixes #240.

Signed-off-by: Harry van Haaren <harryhaaren@gmail.com>