### PR TITLE
Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,10 @@ install:
 - sudo ./waf configure build install && cd ..
 - pip3 install meson
 script:
-- meson build
+- meson --prefix /usr build
 - ninja -C build
 - ninja -C build test
+- DESTDIR=./appdir -C build install
 
 cache: 
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,4 @@ script:
 
 cache: 
   directories:
-    - $PWD/ntk
     - $HOME/.cache/pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+sudo: required
+language: cpp
+dist: xenial
+compiler:
+- gcc
+os:
+- linux
+install:
+- echo $HOME
+- echo $PWD
+- sudo apt-get install libjpeg-dev libsndfile1-dev libsigc++-2.0-dev libfontconfig1-dev libxft-dev libcairo-dev python3-pip python3-setuptools python3-wheel liblo-dev libjack-dev libsamplerate0-dev ninja-build
+- if cd ntk; then git pull; else git://git.tuxfamily.org/gitroot/non/fltk.git ntk && cd ntk; fi
+- sudo ./waf configure build install && cd ..
+- pip3 install meson
+script:
+- meson build
+- ninja -C build
+- ninja -C build test
+
+cache: 
+  directories:
+    - $PWD/ntk
+    - $HOME/.cache/pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,18 @@ script:
 - meson --prefix /usr build
 - ninja -C build
 - ninja -C build test
-- DESTDIR=./appdir ninja -C build install
-
+- DESTDIR=./appdir ninja -C build install ; find ./build/appdir
+- wget -c -nv "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
+- chmod a+x linuxdeployqt-continuous-x86_64.AppImage
+- unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
+- ./linuxdeployqt-continuous-x86_64.AppImage build/appdir/usr/share/applications/*.desktop -appimage
+after_success:
+- wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh
+- bash upload.sh Luppp*.AppImage*  
+branches:
+  except:
+    #- Do not build tags that we create when we upload to GitHub Releases
+    - /^(?i:continuous)/
 cache: 
   directories:
     - $HOME/.cache/pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
 - meson --prefix /usr build
 - ninja -C build
 - ninja -C build test
-- DESTDIR=./appdir -C build install
+- DESTDIR=./appdir ninja -C build install
 
 cache: 
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,11 @@ script:
 - ./linuxdeployqt-continuous-x86_64.AppImage build/appdir/usr/share/applications/*.desktop -appimage
 after_success:
 - wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh
-- bash upload.sh Luppp*.AppImage*  
+- bash upload.sh Luppp*.AppImage*
 branches:
   except:
     #- Do not build tags that we create when we upload to GitHub Releases
     - /^(?i:continuous)/
-cache: 
+cache:
   directories:
     - $HOME/.cache/pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
 - echo $HOME
 - echo $PWD
 - sudo apt-get install libjpeg-dev libsndfile1-dev libsigc++-2.0-dev libfontconfig1-dev libxft-dev libcairo-dev python3-pip python3-setuptools python3-wheel liblo-dev libjack-dev libsamplerate0-dev ninja-build
-- if cd ntk; then git pull; else git://git.tuxfamily.org/gitroot/non/fltk.git ntk && cd ntk; fi
+- if cd ntk; then git pull; else git clone git://git.tuxfamily.org/gitroot/non/fltk.git ntk && cd ntk; fi
 - sudo ./waf configure build install && cd ..
 - pip3 install meson
 script:

--- a/meson.build
+++ b/meson.build
@@ -41,3 +41,7 @@ endforeach
 executable('luppp', luppp_src + [version_hxx],
     install: true,
     dependencies: deps)
+
+install_data('resources/metadata/luppp.desktop', install_dir: 'share/applications')
+install_data('resources/metadata/luppp.appdata.xml', install_dir: 'share/appdata')
+install_data('resources/icons/luppp.png', install_dir: 'share/pixmaps')


### PR DESCRIPTION
This enables and configures Travis CI for Luppp. It does not run tests for now since they sometimes try to open windows, which wont work. 

I still get:

```
[1/42] Generating version.hxx with a custom command.
fatal: No names found, cannot describe anything.
```

This is because we can't read the git information in Travis...

[![Build Status](https://travis-ci.org/georgkrause/openAV-Luppp.svg?branch=travis)](https://travis-ci.org/georgkrause/openAV-Luppp)