### PR TITLE
Implement rubberband and fix clip sync

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ addons:
       - libjack-dev
       - libsamplerate0-dev
       - ninja-build
+      - librubberband-dev
 install:
 - git clone git://git.tuxfamily.org/gitroot/non/fltk.git ntk
 - cd ntk && sudo ./waf configure build install && cd ..

--- a/meson.build
+++ b/meson.build
@@ -29,7 +29,8 @@ dep_names = [
   'jack',
   'sndfile',
   'samplerate',
-  'x11'
+  'x11',
+  'rubberband'
   ]
 deps = []
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,6 +30,10 @@ pkg_check_modules(SAMPLERATE samplerate REQUIRED)
 include_directories( ${SAMPLERATE_INCLUDE_DIRS}  )
 link_directories   ( ${SAMPLERATE_LIBRARY_DIRS}  )
 
+pkg_check_modules(RUBBERBAND rubberband REQUIRED)
+include_directories( ${RUBBERBAND_INCLUDE_DIRS}  )
+link_directories   ( ${RUBBERBAND_LIBRARY_DIRS}  )
+
 # needed for setting icon in WM
 pkg_check_modules(X11 x11 REQUIRED)
 include_directories( ${X11_INCLUDE_DIRS}  )
@@ -85,6 +89,7 @@ target_link_libraries( luppp ${CAIRO_LIBRARIES}      )
 target_link_libraries( luppp ${SNDFILE_LIBRARIES}    )
 target_link_libraries( luppp ${SAMPLERATE_LIBRARIES} )
 target_link_libraries( luppp ${X11_LIBRARIES}        )
+target_link_libraries( luppp ${RUBBERBAND_LIBRARIES} )
 
 # Check build type, linking with gcov for code analysis if needed
 IF(BUILD_TESTS)

--- a/src/gmastertrack.cxx
+++ b/src/gmastertrack.cxx
@@ -272,7 +272,10 @@ GMasterTrack::GMasterTrack(int x, int y, int w, int h, const char* l ) :
 void GMasterTrack::setBpm( int b )
 {
 	bpm = b;
-	tempoDial.value( ( bpm - MIN_TEMPO ) / (float)(MAX_TEMPO - MIN_TEMPO) );
+	if(!tempoDial.mouseClicked) {
+		tempoDial.value(
+			(bpm - MIN_TEMPO) / (float)(MAX_TEMPO - MIN_TEMPO));
+	}
 	std::stringstream s;
 	s << bpm;
 	tempoDial.copy_label( s.str().c_str() );

--- a/src/looper.cxx
+++ b/src/looper.cxx
@@ -127,8 +127,8 @@ void Looper::process(unsigned int nframes, Buffers* buffers)
 			clips[clip]->record( nframes, inputL, inputR);
 		} else if ( clips[clip]->playing() ) {
 			// copy data into tmpBuffer, then pitch-stretch into track buffer
-			long targetFrames = clips[clip]->getBeats() * fpb;
-			long actualFrames = clips[clip]->getActualAudioLength();//getBufferLenght();
+			long targetFrames = fpb;
+			long actualFrames = clips[clip]->getRecFpb();//getBufferLenght();
 #ifdef DEBUG_TIME
 				cout << "FPB: " << fpb << "\n";
 				cout << "Target: " << targetFrames << " - Actual: " << actualFrames << "\n";

--- a/src/looper.cxx
+++ b/src/looper.cxx
@@ -136,7 +136,8 @@ void Looper::process(unsigned int nframes, Buffers* buffers)
 			long double playSpeed = 1.0;
 
 			if ( targetFrames != 0 && actualFrames != 0 ) {
-				playSpeed = (long double)(actualFrames) / (long double)(targetFrames);
+				playSpeed = (long double)(targetFrames) /
+					    (long double)(actualFrames);
 
 #ifdef DEBUG_TIME
 					cout << fixed << setprecision(20) << playSpeed << "\n";
@@ -148,28 +149,7 @@ void Looper::process(unsigned int nframes, Buffers* buffers)
 			float* outL = buffers->audio[Buffers::SEND_TRACK_0_L + trackoffset];
 			float* outR = buffers->audio[Buffers::SEND_TRACK_0_R + trackoffset];
 
-			for(unsigned int i = 0; i < nframes; i++ ) {
-				// REFACTOR into system that is better than per sample function calls
-				float tmpL = 0;
-				float tmpR = 0;
-				clips[clip]->getSample(playSpeed, &tmpL, &tmpR);
-
-				float deltaPitch = 12 * log ( playSpeed ) / log (2);
-				semitoneShift = -deltaPitch;
-
-				// write the pitch-shifted signal to the track buffer
-				//FIXME: pitchShift adds delay even for playSpeed = 1.0!!
-				//we should use something better (e.g librubberband)
-				if(0) { //playSpeed!=1.0f) {
-					pitchShift( 1, &tmpL, &outL[i] );
-					pitchShift( 1, &tmpR, &outR[i] );
-				} else {
-					outL[i]+=tmpL;
-					outR[i]+=tmpR;
-				}
-			}
-
-			//printf("Looper %i playing(), speed = %f\n", track, playSpeed );
+			clips[clip]->getSamples(nframes, playSpeed, outL, outR);
 
 			if ( uiUpdateCounter > uiUpdateConstant ) {
 				jack->getControllerUpdater()->setTrackSceneProgress(track, clip, clips[clip]->getProgress() );

--- a/src/looperclip.cxx
+++ b/src/looperclip.cxx
@@ -209,6 +209,9 @@ void LooperClip::record(int count, float* L, float* R)
 			}
 		}
 	}
+
+	_loaded = true;
+	_recFpb = jack->getTimeManager()->getFpb();
 }
 
 unsigned long LooperClip::recordSpaceAvailable()
@@ -263,6 +266,8 @@ void LooperClip::bar()
 
 	if ( _playing ) {
 		_barsPlayed++;
+		cout << "Clip " << track << ":" << scene << " " << _playhead
+		     << "\n";
 	}
 
 	// FIXME assumes 4 beats in a bar
@@ -489,6 +494,15 @@ void LooperClip::getSample(long double playSpeed, float* L, float* R)
 		     _playhead >= _buffer->getSize() ||
 		     _playhead < 0  ) {
 			resetPlayHead();
+			
+			// FIXME is there a better way than just output 0 if frames are missing?
+			*L = 0.f;
+			*R = 0.f;
+			_playhead += playSpeed;
+			return;
+
+			EventGuiPrint e( "LooperClip resetting _playhead" );
+			//writeToGuiRingbuffer( &e );
 		}
 
 		std::vector<float>& vL = _buffer->getDataL();

--- a/src/looperclip.cxx
+++ b/src/looperclip.cxx
@@ -456,13 +456,6 @@ void
 LooperClip::getSamples(
 	unsigned int nframes, long double playspeed, float *L, float *R)
 {
-	stretcher->setTimeRatio(playspeed);
-	int samples_available = stretcher->available();
-
-	float *bufs[2];
-	bufs[0] = L;
-	bufs[1] = R;
-
 	vector<float> vL;
 	vector<float> vR;
 
@@ -471,21 +464,38 @@ LooperClip::getSamples(
 		vR = _buffer->getDataR();
 	}
 
-	while(samples_available < nframes) {
-		size_t req = stretcher->getSamplesRequired();
-		size_t use = min(req, (size_t)nframes);
-		for(unsigned int i = 0; i < use; i++) {
+	if(playspeed != 1.0) {
+		stretcher->setTimeRatio(playspeed);
+		int samples_available = stretcher->available();
+
+		float *bufs[2];
+		bufs[0] = L;
+		bufs[1] = R;
+
+		while(samples_available < nframes) {
+			size_t req = stretcher->getSamplesRequired();
+			size_t use = min(req, (size_t)nframes);
+			for(unsigned int i = 0; i < use; i++) {
+				if(_playhead > _recordhead)
+					_playhead = 0;
+				L[i] = vL[_playhead];
+				R[i] = vR[_playhead];
+				_playhead++;
+			}
+			stretcher->process(bufs, use, false);
+			samples_available = stretcher->available();
+		}
+		stretcher->retrieve(bufs, nframes);
+		
+	} else {
+		for(unsigned int i = 0; i < nframes; i++) {
 			if(_playhead > _recordhead)
 				_playhead = 0;
 			L[i] = vL[_playhead];
 			R[i] = vR[_playhead];
 			_playhead++;
 		}
-		stretcher->process(bufs, use, false);
-		samples_available = stretcher->available();
 	}
-
-	stretcher->retrieve(bufs, nframes);
 };
 
 void LooperClip::getSample(long double playSpeed, float* L, float* R)

--- a/src/looperclip.cxx
+++ b/src/looperclip.cxx
@@ -63,6 +63,8 @@ void LooperClip::init()
 
 	resetQueues();
 
+	_smoothVolume = 1;
+
 	if ( _buffer ) {
 		_buffer->init();
 	}
@@ -366,6 +368,8 @@ void LooperClip::setPlaying()
 
 		resetQueues();
 
+		_smoothVolume = 0;
+
 		_barsPlayed = 0;
 		_playhead 	= 0;
 	} else {
@@ -477,9 +481,12 @@ LooperClip::getSamples(
 		for(unsigned int i = 0; i < use; i++) {
 			if(_playhead > _recordhead)
 				_playhead = 0;
-			L[i] = vL[_playhead];
-			R[i] = vR[_playhead];
+			L[i] = vL[_playhead] * _smoothVolume;
+			R[i] = vR[_playhead] * _smoothVolume;
 			_playhead++;
+
+			_smoothVolume += jack->smoothing_value *
+				       (1 - _smoothVolume);
 		}
 		stretcher->process(bufs, use, false);
 		samples_available = stretcher->available();

--- a/src/looperclip.cxx
+++ b/src/looperclip.cxx
@@ -112,6 +112,7 @@ void LooperClip::load( AudioBuffer* ab )
 
 	// set the endpoint to the buffer's size
 	_recordhead = _buffer->getSize();
+	_recFpb = _recordhead / _buffer->getBeats();
 
 #ifdef DEBUG_BUFFER
 	char buffer [50];

--- a/src/looperclip.hxx
+++ b/src/looperclip.hxx
@@ -93,6 +93,10 @@ public:
 	long  getActualAudioLength();
 	/// Return Size of the Buffer
 	size_t audioBufferSize();
+	int
+	getRecFpb() {
+		return _recFpb;
+	};
 
 	/// Queue Play
 	void  queuePlay();
@@ -145,6 +149,7 @@ private:
 
 	long double _playhead;
 	float _recordhead;
+	int _recFpb;
 
 	unsigned int _barsPlayed;
 	AudioBuffer* _buffer;

--- a/src/looperclip.hxx
+++ b/src/looperclip.hxx
@@ -151,6 +151,8 @@ private:
 	float _recordhead;
 	int _recFpb;
 
+	float _smoothVolume;
+
 	unsigned int _barsPlayed;
 	AudioBuffer* _buffer;
 

--- a/src/looperclip.hxx
+++ b/src/looperclip.hxx
@@ -24,6 +24,8 @@
 #include "config.hxx"
 #include "gridlogic.hxx"
 
+#include "rubberband/RubberBandStretcher.h"
+
 class AudioBuffer;
 
 /** LooperClip
@@ -58,6 +60,8 @@ public:
 	/// Return one Sample according to current playSpeed
 	void getSample(long double playSpeed, float* L, float* R);
 	/// Record $count Samples into internal Buffer
+	void
+	getSamples(unsigned int nframes, long double playspeed, float * L, float * R);
 	void record(int count, float* L, float* R);
 
 	/// TimeObserver override
@@ -161,6 +165,7 @@ private:
 
 	/// Updates all the controllers with the current state
 	void updateController();
+	RubberBand::RubberBandStretcher *stretcher;
 };
 
 #endif // LUPPP_LOOPER_CLIP_H

--- a/src/metronome.cxx
+++ b/src/metronome.cxx
@@ -106,7 +106,7 @@ void Metronome::setFpb(double f)
 	fpb = f;
 
 	// disable play until next beat
-	playPoint = endPoint + 1;
+	//playPoint = endPoint + 1;
 }
 
 void Metronome::process(int nframes, Buffers* buffers)

--- a/src/timemanager.cxx
+++ b/src/timemanager.cxx
@@ -204,13 +204,12 @@ void TimeManager::setTransportState( TRANSPORT_STATE s )
 void TimeManager::process(Buffers* buffers)
 {
 	if(_bpmChangeQueued) {
-		_fpbLag += _nextFpb - _fpbLag;
-		cout << "Lag: " << _fpbLag << " Next: " << _nextFpb << " Actual: " << _fpb << "\n";
+		_fpbLag = _nextFpb;
+		cout << "Lag: " << _fpbLag << " Next: " << _nextFpb
+		     << " Actual: " << _fpb << "\n";
 		setFpb(_fpbLag);
-		if (abs((int)_fpbLag - (int)_nextFpb) <= 1) {
-			_bpmChangeQueued = false;
-			cout << "finish\n";
-		}
+		_bpmChangeQueued = false;
+		cout << "finish\n";
 	}
 	// time signature?
 	//buffers->transportPosition->beats_per_bar = 4;

--- a/src/timemanager.cxx
+++ b/src/timemanager.cxx
@@ -204,7 +204,7 @@ void TimeManager::setTransportState( TRANSPORT_STATE s )
 void TimeManager::process(Buffers* buffers)
 {
 	if(_bpmChangeQueued) {
-		_fpbLag += 0.1 * (_nextFpb - _fpbLag);
+		_fpbLag += _nextFpb - _fpbLag;
 		cout << "Lag: " << _fpbLag << " Next: " << _nextFpb << " Actual: " << _fpb << "\n";
 		setFpb(_fpbLag);
 		if (abs((int)_fpbLag - (int)_nextFpb) <= 1) {

--- a/src/timemanager.cxx
+++ b/src/timemanager.cxx
@@ -107,9 +107,10 @@ void TimeManager::setFpb(double f)
 	// beatCounter = 0;
 	// beatFrameCountdown = -1;
 
-	double ratio = f / _fpb;
-	cout << "Faktor: " << ratio << "\n";
-	beatFrameCountdown *= ratio;
+	long double ratio = (long double)f / (long double)_fpb;
+	cout << "Faktor: " << ratio << "alt: " << beatFrameCountdown << "\n";
+	beatFrameCountdown = beatFrameCountdown * ratio;
+	cout << "Countdown: " << beatFrameCountdown << "\n";
 
 	_fpb = f;
 	int bpm = ( samplerate * 60) / f;

--- a/src/timemanager.hxx
+++ b/src/timemanager.hxx
@@ -68,6 +68,7 @@ private:
 	/// number of frames per beat
 	double _fpb;
 	double _nextFpb;
+	double _fpbLag;
 
 	/// holds the number of frames processed
 	long long totalFrameCounter;


### PR DESCRIPTION
This branch will enable on the fly tempo changes again. There are two problems to be solved:

* When changing the tempo, the pitch needs to be corrected
* When changing the tempo, clips need to stay in sync (with each other but also with the timemanager)

This branch currently solve both issues by implementing rubberband for the timestretching and change the way the clips are synced to each other. I did some minor testing and more is welcome. Please report any issues. 

**This is work in progress and should be considered as unstable.**

AppImages for testing can be found here: https://github.com/openAVproductions/openAV-Luppp/releases/tag/continuous-rubberband

Stuff to test:

- [ ] Record clips
- [ ] Load clips
- [ ] Change tempo, huge steps and slow tempo changes
- [ ] Record after tempo change
- [ ] Check audio quality after tempo changes 