### PR TITLE
Move session directory to .local/share

### DIFF
--- a/src/diskreader.cxx
+++ b/src/diskreader.cxx
@@ -98,7 +98,7 @@ int DiskReader::loadPreferences()
 		string dir=getenv("HOME");
 		if(projDir) {
 			stringstream s;
-			s<<dir<<"/"<<projDir->valuestring;
+			s<<dir<<"/.local/share"<<"/"<<projDir->valuestring;
 			dir=s.str();
 		}
 		gui->setProjectsDir(dir);

--- a/src/gui.cxx
+++ b/src/gui.cxx
@@ -180,9 +180,11 @@ static void gui_header_callback(Fl_Widget *w, void *data)
 
 		return;
 	} else if ( strcmp(m->label(), "Save Session   ") == 0 ) {
-		const char* name = fl_input( "Save session as", gui->getDiskWriter()->getLastSaveName().c_str() );
+		const string projectsDir = gui->getProjectsDir();
+		string prompt = "Save session as " + projectsDir;
+		const char* name = fl_input( prompt.c_str(), gui->getDiskWriter()->getLastSaveName().c_str() );
 		if ( name ) {
-			gui->getDiskWriter()->initialize( gui->getProjectsDir().c_str(), name );
+			gui->getDiskWriter()->initialize( projectsDir, name );
 			LUPPP_NOTE("%s %s","Saving session as ", name );
 			EventSessionSave e;
 			writeToDspRingbuffer( &e );


### PR DESCRIPTION
This pull request updates the Luppp session files to be stored in `$HOME/.local/share/luppp` by default. This change aligns with common Linux conventions for storing application data.

This keeps user home directories cleaner :)