### PR TITLE
Keyboard handler rewrite

### DIFF
--- a/src/avtk/clipselector.cxx
+++ b/src/avtk/clipselector.cxx
@@ -277,9 +277,9 @@ int ClipSelector::handle(int event)
 					{0},
 					//{ "Record" },
 					{ "Use as tempo" },
+					{ "Assign Hotkey" },
 					{ "Rename", 0, 0, 0, FL_MENU_DIVIDER},
 					{ "Clear" },
-					{ "Assign Hotkey" },
 					{ 0 }
 				};
 				Fl_Menu_Item *m = (Fl_Menu_Item*) rclick_menu->popup(Fl::event_x(), Fl::event_y(), 0, 0, 0);
@@ -303,7 +303,7 @@ int ClipSelector::handle(int event)
 					
 					if (hotkey && strlen(hotkey) == 1) {
 						int newKey = static_cast<int>(hotkey[0]);
-						addKeyToGrid(newKey, ID, clipNum);
+						updateKeyToGrid(currentKey, newKey, ID, clipNum);
 					}
 
 				} else if ( strcmp(m->label(), "Save") == 0 ) {

--- a/src/avtk/clipselector.cxx
+++ b/src/avtk/clipselector.cxx
@@ -305,7 +305,9 @@ int ClipSelector::handle(int event)
 					}
 
 					int newKey = dialog->getHotkey();
-					updateKeyToGrid(currentKey, newKey, ID, clipNum);
+					if (newKey) {
+						updateKeyToGrid(currentKey, newKey, ID, clipNum);
+					}
 					
 				} else if ( strcmp(m->label(), "Save") == 0 ) {
 					//gui->saveBufferPath = "/tmp/test.wav";

--- a/src/avtk/clipselector.cxx
+++ b/src/avtk/clipselector.cxx
@@ -18,6 +18,7 @@
 
 
 #include "clipselector.hxx"
+#include "hotkeydialog.hxx"
 
 #include <unistd.h>
 
@@ -288,7 +289,6 @@ int ClipSelector::handle(int event)
 				} else if ( strcmp(m->label(), "Load") == 0 ) {
 					gui->selectLoadSample( ID, clipNum );
 				} else if ( strcmp(m->label(), "Assign Hotkey") == 0 ) {
-					
 					int currentKey = getCurrentKeyForClip(ID, clipNum);
 					char currentKeyStr[2] = {0};
 					
@@ -296,16 +296,17 @@ int ClipSelector::handle(int event)
 						currentKeyStr[0] = static_cast<char>(currentKey);
 					}
 										
-					const char* hotkey = fl_input( "Assign hotkey: ", currentKeyStr );
-					// char buffer [50];
-					// snprintf(buffer, sizeof(buffer), "Hot key assignment: %i, %i, %s", ID, clipNum, hotkey);
-					// printf("%s\n", buffer);
-					
-					if (hotkey && strlen(hotkey) == 1) {
-						int newKey = static_cast<int>(hotkey[0]);
-						updateKeyToGrid(currentKey, newKey, ID, clipNum);
+					string title = "Assign New Hotkey";
+					string message = "\nCurrent assignment: " + string(1,  currentKeyStr[0]) + "\n\nPress new hotkey:";
+					HotkeyDialog* dialog = new HotkeyDialog(300, 125, title.c_str(), message.c_str());
+					dialog->show();
+					while (dialog->shown()) {
+						Fl::wait();
 					}
 
+					int newKey = dialog->getHotkey();
+					updateKeyToGrid(currentKey, newKey, ID, clipNum);
+					
 				} else if ( strcmp(m->label(), "Save") == 0 ) {
 					//gui->saveBufferPath = "/tmp/test.wav";
 					char* tmp = gui->selectSavePath();

--- a/src/avtk/clipselector.cxx
+++ b/src/avtk/clipselector.cxx
@@ -24,6 +24,7 @@
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 
 #include "../gui.hxx"
+#include "../hotkeymanager.hxx"
 
 extern Gui* gui;
 
@@ -278,6 +279,7 @@ int ClipSelector::handle(int event)
 					{ "Use as tempo" },
 					{ "Rename", 0, 0, 0, FL_MENU_DIVIDER},
 					{ "Clear" },
+					{ "Assign Hotkey" },
 					{ 0 }
 				};
 				Fl_Menu_Item *m = (Fl_Menu_Item*) rclick_menu->popup(Fl::event_x(), Fl::event_y(), 0, 0, 0);
@@ -285,6 +287,25 @@ int ClipSelector::handle(int event)
 					return 0;
 				} else if ( strcmp(m->label(), "Load") == 0 ) {
 					gui->selectLoadSample( ID, clipNum );
+				} else if ( strcmp(m->label(), "Assign Hotkey") == 0 ) {
+					
+					int currentKey = getCurrentKeyForClip(ID, clipNum);
+					char currentKeyStr[2] = {0};
+					
+					if (currentKey) {
+						currentKeyStr[0] = static_cast<char>(currentKey);
+					}
+										
+					const char* hotkey = fl_input( "Assign hotkey: ", currentKeyStr );
+					// char buffer [50];
+					// snprintf(buffer, sizeof(buffer), "Hot key assignment: %i, %i, %s", ID, clipNum, hotkey);
+					// printf("%s\n", buffer);
+					
+					if (hotkey && strlen(hotkey) == 1) {
+						int newKey = static_cast<int>(hotkey[0]);
+						addKeyToGrid(newKey, ID, clipNum);
+					}
+
 				} else if ( strcmp(m->label(), "Save") == 0 ) {
 					//gui->saveBufferPath = "/tmp/test.wav";
 					char* tmp = gui->selectSavePath();

--- a/src/avtk/hotkeydialog.cxx
+++ b/src/avtk/hotkeydialog.cxx
@@ -1,0 +1,39 @@
+#include "hotkeydialog.hxx"
+#include <FL/Fl.H>
+#include <iostream>
+
+HotkeyDialog::HotkeyDialog(int w, int h, const char* title, const char* message_text)
+    : Fl_Window(w, h, title), hotkey(0) {
+    message = new Fl_Box(10, 10, w - 20, 30, message_text);
+    cancel_button = new Fl_Button(w / 2 - 40, h - 40, 80, 30, "Cancel");
+    cancel_button->callback(Cancel_CB, this);
+    end();
+}
+
+int HotkeyDialog::getHotkey() const {
+    return hotkey;
+}
+
+int HotkeyDialog::handle(int event) {
+    switch (event) {
+    case FL_KEYDOWN:
+        hotkey = Fl::event_key();
+        std::cout << "Hotkey captured: " << hotkey << std::endl;
+        hide();
+        return 1;
+    case FL_SHORTCUT:
+        if (Fl::event_key() == FL_Escape) {
+            hide();
+            return 1;
+        }
+        break;
+    default:
+        break;
+    }
+    return Fl_Window::handle(event);
+}
+
+void HotkeyDialog::Cancel_CB(Fl_Widget*, void* v) {
+    HotkeyDialog* dialog = (HotkeyDialog*)v;
+    dialog->hide();
+}

--- a/src/avtk/hotkeydialog.cxx
+++ b/src/avtk/hotkeydialog.cxx
@@ -18,7 +18,7 @@ int HotkeyDialog::handle(int event) {
     switch (event) {
     case FL_KEYDOWN:
         hotkey = Fl::event_key();
-        std::cout << "Hotkey captured: " << hotkey << std::endl;
+        //std::cout << "Hotkey captured: " << hotkey << std::endl;
         hide();
         return 1;
     case FL_SHORTCUT:

--- a/src/avtk/hotkeydialog.hxx
+++ b/src/avtk/hotkeydialog.hxx
@@ -1,0 +1,24 @@
+#ifndef HOTKEYDIALOG_H
+#define HOTKEYDIALOG_H
+
+#include <FL/Fl_Window.H>
+#include <FL/Fl_Button.H>
+#include <FL/Fl_Box.H>
+
+class HotkeyDialog : public Fl_Window {
+public:
+    HotkeyDialog(int w, int h, const char* title = 0, const char* message_text = 0);
+    int getHotkey() const;
+
+protected:
+    int handle(int event) override;
+
+private:
+    static void Cancel_CB(Fl_Widget*, void* v);
+
+    Fl_Box* message;
+    Fl_Button* cancel_button;
+    int hotkey;
+};
+
+#endif // HOTKEYDIALOG_H

--- a/src/avtk/meson.build
+++ b/src/avtk/meson.build
@@ -1,1 +1,1 @@
-luppp_src += files( 'bindings.cxx', 'volume.cxx', 'clipselector.cxx')
+luppp_src += files( 'bindings.cxx', 'volume.cxx', 'clipselector.cxx', 'hotkeydialog.cxx')

--- a/src/gui.cxx
+++ b/src/gui.cxx
@@ -37,6 +37,7 @@ extern Jack* jack;
 #include <FL/x.H>
 #include <FL/fl_draw.H>
 
+#include <map>
 #include <stdlib.h>
 #include <FL/Fl.H>
 #include <FL/fl_ask.H>
@@ -569,306 +570,61 @@ void Gui::askQuit()
 
 int Gui::keyboardHandler(int event)
 {
+	// Define the grid mapping of hotkeys
+	std::map<int, std::pair<int, int>> keyToGrid = {
+		{49, {0, 0}}, {50, {1, 0}}, {51, {2, 0}}, {52, {3, 0}}, {53, {4, 0}}, {54, {5, 0}}, {55, {6, 0}}, {56, {7, 0}}, // 1-8
+		{113, {0, 1}}, {119, {1, 1}}, {101, {2, 1}}, {114, {3, 1}}, {116, {4, 1}}, {121, {5, 1}}, {117, {6, 1}}, {105, {7, 1}}, // q-i
+		{97, {0, 2}}, {115, {1, 2}}, {100, {2, 2}}, {102, {3, 2}}, {103, {4, 2}}, {104, {5, 2}}, {106, {6, 2}}, {107, {7, 2}}, // a-k
+		{122, {0, 3}}, {120, {1, 3}}, {99, {2, 3}}, {118, {3, 3}}, {98, {4, 3}}, {110, {5, 3}}, {109, {6, 3}}, {44, {7, 3}}, // z-,
+	};
 
 	switch( event ) {
 	case FL_SHORTCUT:
-		if     ( strcmp( Fl::event_text(), "1" ) == 0 ) {
-			EventGridEvent e( 0, 0, true );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "2" ) == 0 ) {
-			EventGridEvent e( 1, 0, true );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "3" ) == 0 ) {
-			EventGridEvent e( 2, 0, true );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "4" ) == 0 ) {
-			EventGridEvent e( 3, 0, true );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "5" ) == 0 ) {
-			EventGridEvent e( 4, 0, true );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "6" ) == 0 ) {
-			EventGridEvent e( 5, 0, true );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "7" ) == 0 ) {
-			EventGridEvent e( 6, 0, true );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "8" ) == 0 ) {
-			EventGridEvent e( 7, 0, true );
-			writeToDspRingbuffer( &e );
-			return 1;
-		}
 
-		else if( strcmp( Fl::event_text(), "!" ) == 0 ) {
-			EventGridState e( 0, 0, GridLogic::STATE_EMPTY );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "@" ) == 0 ) {
-			EventGridState e( 1, 0, GridLogic::STATE_EMPTY );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "\"" ) == 0 ) {
-			EventGridState e( 1, 0, GridLogic::STATE_EMPTY );        // for UK/Ireland keyboards
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "#" ) == 0 ) {
-			EventGridState e( 2, 0, GridLogic::STATE_EMPTY );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "£" ) == 0 ) {
-			EventGridState e( 2, 0, GridLogic::STATE_EMPTY );        // for UK/Ireland keyboards
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "$" ) == 0 ) {
-			EventGridState e( 3, 0, GridLogic::STATE_EMPTY );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "%" ) == 0 ) {
-			EventGridState e( 4, 0, GridLogic::STATE_EMPTY );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "^" ) == 0 ) {
-			EventGridState e( 5, 0, GridLogic::STATE_EMPTY );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "&" ) == 0 ) {
-			EventGridState e( 6, 0, GridLogic::STATE_EMPTY );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "*" ) == 0 ) {
-			EventGridState e( 7, 0, GridLogic::STATE_EMPTY );
-			writeToDspRingbuffer( &e );
-			return 1;
-		}
+		const char* eventText = Fl::event_text();
+		const int eventKey = Fl::event_key();
+		char buffer [50];
+		snprintf(buffer, sizeof(buffer), "Keyboard input: %s | %i", eventText, eventKey);
+		printf("%s\n", buffer);
+		// Check if the event text is a single character and in our map
+        if (eventKey) {
 
-		else if( strcmp( Fl::event_text(), "q" ) == 0 ) {
-			EventGridEvent e( 0, 1, true );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "w" ) == 0 ) {
-			EventGridEvent e( 1, 1, true );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "e" ) == 0 ) {
-			EventGridEvent e( 2, 1, true );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "r" ) == 0 ) {
-			EventGridEvent e( 3, 1, true );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "t" ) == 0 ) {
-			EventGridEvent e( 4, 1, true );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "y" ) == 0 ) {
-			EventGridEvent e( 5, 1, true );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "u" ) == 0 ) {
-			EventGridEvent e( 6, 1, true );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "i" ) == 0 ) {
-			EventGridEvent e( 7, 1, true );
-			writeToDspRingbuffer( &e );
-			return 1;
-		}
+            if (keyToGrid.find(eventKey) != keyToGrid.end()) {
+                auto gridPos = keyToGrid[eventKey];
+                int x = gridPos.first;
+                int y = gridPos.second;
 
-		else if( strcmp( Fl::event_text(), "Q" ) == 0 ) {
-			EventGridState e( 0, 1, GridLogic::STATE_EMPTY );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "W" ) == 0 ) {
-			EventGridState e( 1, 1, GridLogic::STATE_EMPTY );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "E" ) == 0 ) {
-			EventGridState e( 2, 1, GridLogic::STATE_EMPTY );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "R" ) == 0 ) {
-			EventGridState e( 3, 1, GridLogic::STATE_EMPTY );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "T" ) == 0 ) {
-			EventGridState e( 4, 1, GridLogic::STATE_EMPTY );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "Y" ) == 0 ) {
-			EventGridState e( 5, 1, GridLogic::STATE_EMPTY );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "U" ) == 0 ) {
-			EventGridState e( 6, 1, GridLogic::STATE_EMPTY );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "I" ) == 0 ) {
-			EventGridState e( 7, 1, GridLogic::STATE_EMPTY );
-			writeToDspRingbuffer( &e );
-			return 1;
-		}
+                // Check if Shift is held down
+                bool shiftHeld = (Fl::event_state() & FL_SHIFT) != 0;
 
-		else if( strcmp( Fl::event_text(), "a" ) == 0 ) {
-			EventGridEvent e( 0, 2, true );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "s" ) == 0 ) {
-			EventGridEvent e( 1, 2, true );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "d" ) == 0 ) {
-			EventGridEvent e( 2, 2, true );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "f" ) == 0 ) {
-			EventGridEvent e( 3, 2, true );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "g" ) == 0 ) {
-			EventGridEvent e( 4, 2, true );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "h" ) == 0 ) {
-			EventGridEvent e( 5, 2, true );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "j" ) == 0 ) {
-			EventGridEvent e( 6, 2, true );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "k" ) == 0 ) {
-			EventGridEvent e( 7, 2, true );
-			writeToDspRingbuffer( &e );
-			return 1;
-		}
+                if (shiftHeld) {
+                    EventGridState e(x, y, GridLogic::STATE_EMPTY);
+                    writeToDspRingbuffer(&e);
+                } else {
+                    EventGridEvent e(x, y, true);
+                    writeToDspRingbuffer(&e);
+                }
 
-		else if( strcmp( Fl::event_text(), "A" ) == 0 ) {
-			EventGridState e( 0, 2, GridLogic::STATE_EMPTY );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "S" ) == 0 ) {
-			EventGridState e( 1, 2, GridLogic::STATE_EMPTY );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "D" ) == 0 ) {
-			EventGridState e( 2, 2, GridLogic::STATE_EMPTY );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "F" ) == 0 ) {
-			EventGridState e( 3, 2, GridLogic::STATE_EMPTY );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "G" ) == 0 ) {
-			EventGridState e( 4, 2, GridLogic::STATE_EMPTY );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "H" ) == 0 ) {
-			EventGridState e( 5, 2, GridLogic::STATE_EMPTY );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "J" ) == 0 ) {
-			EventGridState e( 6, 2, GridLogic::STATE_EMPTY );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "K" ) == 0 ) {
-			EventGridState e( 7, 2, GridLogic::STATE_EMPTY );
-			writeToDspRingbuffer( &e );
-			return 1;
+                return 1;
+            } else if( strcmp( eventText, "9" ) == 0 ) {
+				EventGridLaunchScene e( 0 );
+				writeToDspRingbuffer( &e );
+				return 1;
+			} else if( strcmp( eventText, "o" ) == 0 ) {
+				EventGridLaunchScene e( 1 );
+				writeToDspRingbuffer( &e );
+				return 1;
+			} else if( strcmp( eventText, "l" ) == 0 ) {
+				EventGridLaunchScene e( 2 );
+				writeToDspRingbuffer( &e );
+				return 1;
+			} else if( strcmp( eventText, "." ) == 0 ) {
+				EventGridLaunchScene e( 3 );
+				writeToDspRingbuffer( &e );
+				return 1;
+			}
 		}
-
-		else if( strcmp( Fl::event_text(), "z" ) == 0 ) {
-			EventGridEvent e( 0, 3, true );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "x" ) == 0 ) {
-			EventGridEvent e( 1, 3, true );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "c" ) == 0 ) {
-			EventGridEvent e( 2, 3, true );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "v" ) == 0 ) {
-			EventGridEvent e( 3, 3, true );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "b" ) == 0 ) {
-			EventGridEvent e( 4, 3, true );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "n" ) == 0 ) {
-			EventGridEvent e( 5, 3, true );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "m" ) == 0 ) {
-			EventGridEvent e( 6, 3, true );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "," ) == 0 ) {
-			EventGridEvent e( 7, 3, true );
-			writeToDspRingbuffer( &e );
-			return 1;
-		}
-
-		else if( strcmp( Fl::event_text(), "Z" ) == 0 ) {
-			EventGridState e( 0, 3, GridLogic::STATE_EMPTY );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "X" ) == 0 ) {
-			EventGridState e( 1, 3, GridLogic::STATE_EMPTY );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "C" ) == 0 ) {
-			EventGridState e( 2, 3, GridLogic::STATE_EMPTY );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "V" ) == 0 ) {
-			EventGridState e( 3, 3, GridLogic::STATE_EMPTY );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "B" ) == 0 ) {
-			EventGridState e( 4, 3, GridLogic::STATE_EMPTY );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "N" ) == 0 ) {
-			EventGridState e( 5, 3, GridLogic::STATE_EMPTY );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "M" ) == 0 ) {
-			EventGridState e( 6, 3, GridLogic::STATE_EMPTY );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "<" ) == 0 ) {
-			EventGridState e( 7, 3, GridLogic::STATE_EMPTY );
-			writeToDspRingbuffer( &e );
-			return 1;
-		}
-
-		else if( strcmp( Fl::event_text(), "9" ) == 0 ) {
-			EventGridLaunchScene e( 0 );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "o" ) == 0 ) {
-			EventGridLaunchScene e( 1 );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "l" ) == 0 ) {
-			EventGridLaunchScene e( 2 );
-			writeToDspRingbuffer( &e );
-			return 1;
-		} else if( strcmp( Fl::event_text(), "." ) == 0 ) {
-			EventGridLaunchScene e( 3 );
-			writeToDspRingbuffer( &e );
-			return 1;
-		}
+		
 
 		else {
 			//printf("%s\n", Fl::event_text() ); return 1;

--- a/src/gui.cxx
+++ b/src/gui.cxx
@@ -17,6 +17,7 @@
  */
 
 #include "gui.hxx"
+#include "hotkeymanager.hxx"
 #include "avtk/avtk_image.h"
 #include "avtk/avtk_button.h"
 
@@ -570,24 +571,17 @@ void Gui::askQuit()
 
 int Gui::keyboardHandler(int event)
 {
-	// Define the grid mapping of hotkeys
-	std::map<int, std::pair<int, int>> keyToGrid = {
-		{49, {0, 0}}, {50, {1, 0}}, {51, {2, 0}}, {52, {3, 0}}, {53, {4, 0}}, {54, {5, 0}}, {55, {6, 0}}, {56, {7, 0}}, // 1-8
-		{113, {0, 1}}, {119, {1, 1}}, {101, {2, 1}}, {114, {3, 1}}, {116, {4, 1}}, {121, {5, 1}}, {117, {6, 1}}, {105, {7, 1}}, // q-i
-		{97, {0, 2}}, {115, {1, 2}}, {100, {2, 2}}, {102, {3, 2}}, {103, {4, 2}}, {104, {5, 2}}, {106, {6, 2}}, {107, {7, 2}}, // a-k
-		{122, {0, 3}}, {120, {1, 3}}, {99, {2, 3}}, {118, {3, 3}}, {98, {4, 3}}, {110, {5, 3}}, {109, {6, 3}}, {44, {7, 3}}, // z-,
-	};
-
 	switch( event ) {
 	case FL_SHORTCUT:
 
 		const char* eventText = Fl::event_text();
-		const int eventKey = Fl::event_key();
-		char buffer [50];
-		snprintf(buffer, sizeof(buffer), "Keyboard input: %s | %i", eventText, eventKey);
-		printf("%s\n", buffer);
+		int eventKey = Fl::event_key();
+		
 		// Check if the event text is a single character and in our map
         if (eventKey) {
+			char buffer [50];
+			snprintf(buffer, sizeof(buffer), "Keyboard input: %s | %i", eventText, eventKey);
+			printf("%s\n", buffer);
 
             if (keyToGrid.find(eventKey) != keyToGrid.end()) {
                 auto gridPos = keyToGrid[eventKey];

--- a/src/gui.cxx
+++ b/src/gui.cxx
@@ -579,9 +579,9 @@ int Gui::keyboardHandler(int event)
 		
 		// Check if the event text is a single character and in our map
         if (eventKey) {
-			char buffer [50];
-			snprintf(buffer, sizeof(buffer), "Keyboard input: %s | %i", eventText, eventKey);
-			printf("%s\n", buffer);
+			// char buffer [50];
+			// snprintf(buffer, sizeof(buffer), "Keyboard input: %s | %i", eventText, eventKey);
+			// printf("%s\n", buffer);
 
             if (keyToGrid.find(eventKey) != keyToGrid.end()) {
                 auto gridPos = keyToGrid[eventKey];

--- a/src/hotkeymanager.cxx
+++ b/src/hotkeymanager.cxx
@@ -1,0 +1,22 @@
+#include "hotkeymanager.hxx"
+#include <map>
+
+std::map<int, std::pair<int, int>> keyToGrid = {
+    {49, {0, 0}}, {50, {1, 0}}, {51, {2, 0}}, {52, {3, 0}}, {53, {4, 0}}, {54, {5, 0}}, {55, {6, 0}}, {56, {7, 0}}, // 1-8
+    {113, {0, 1}}, {119, {1, 1}}, {101, {2, 1}}, {114, {3, 1}}, {116, {4, 1}}, {121, {5, 1}}, {117, {6, 1}}, {105, {7, 1}}, // q-i
+    {97, {0, 2}}, {115, {1, 2}}, {100, {2, 2}}, {102, {3, 2}}, {103, {4, 2}}, {104, {5, 2}}, {106, {6, 2}}, {107, {7, 2}}, // a-k
+    {122, {0, 3}}, {120, {1, 3}}, {99, {2, 3}}, {118, {3, 3}}, {98, {4, 3}}, {110, {5, 3}}, {109, {6, 3}}, {44, {7, 3}}, // z-,
+};
+
+void addKeyToGrid(int key, int id, int clipNumber) {
+    keyToGrid[key] = {id, clipNumber};
+}
+
+int getCurrentKeyForClip(int id, int clipNumber) {
+    for (const auto& pair : keyToGrid) {
+        if (pair.second.first == id && pair.second.second == clipNumber) {
+            return pair.first;
+        }
+    }
+    return 0;
+}

--- a/src/hotkeymanager.cxx
+++ b/src/hotkeymanager.cxx
@@ -12,6 +12,22 @@ void addKeyToGrid(int key, int id, int clipNumber) {
     keyToGrid[key] = {id, clipNumber};
 }
 
+void updateKeyToGrid(int oldKey, int newkey, int id, int clipNumber) {
+    removeKeyFromGrid(oldKey, id, clipNumber);
+    removeKeyFromGrid(newkey, id, clipNumber); // remove previous assignment of new key if it exists
+    addKeyToGrid(newkey, id, clipNumber);
+}
+
+void removeKeyFromGrid(int key, int id, int clipNumber) {
+    for (auto it = keyToGrid.begin(); it != keyToGrid.end(); ) {
+        if (it->second.first == id && it->second.second == clipNumber) {
+            it = keyToGrid.erase(it);  // Remove the existing mapping and get the new iterator
+        } else {
+            ++it;  // Move to the next element
+        }
+    }
+}
+
 int getCurrentKeyForClip(int id, int clipNumber) {
     for (const auto& pair : keyToGrid) {
         if (pair.second.first == id && pair.second.second == clipNumber) {

--- a/src/hotkeymanager.hxx
+++ b/src/hotkeymanager.hxx
@@ -7,6 +7,8 @@
 extern std::map<int, std::pair<int, int>> keyToGrid;
 
 void addKeyToGrid(int key, int id, int clipNumber);
+void updateKeyToGrid(int oldKey, int newkey, int id, int clipNumber);
+void removeKeyFromGrid(int key, int id, int clipNumber);
 int getCurrentKeyForClip(int id, int clipNumber);
 
 #endif // HOTKEYMANAGER_H

--- a/src/hotkeymanager.hxx
+++ b/src/hotkeymanager.hxx
@@ -1,0 +1,12 @@
+#ifndef HOTKEYMANAGER_H
+#define HOTKEYMANAGER_H
+
+#include <map>
+#include <utility>
+
+extern std::map<int, std::pair<int, int>> keyToGrid;
+
+void addKeyToGrid(int key, int id, int clipNumber);
+int getCurrentKeyForClip(int id, int clipNumber);
+
+#endif // HOTKEYMANAGER_H

--- a/src/meson.build
+++ b/src/meson.build
@@ -18,6 +18,7 @@ luppp_src = files(
   'gridlogic.cxx',
   'gtrack.cxx',
   'gui.cxx',
+  'hotkeymanager.cxx',
   'jack.cxx',
   'jacksendreturn.cxx',
   'logic.cxx',


### PR DESCRIPTION
I rewrote how LUPPP handles the keyboard shortcuts. This pull request adds a new context menu button when right clicking on a clip. It shows the current hotkey assigned to this clip and allows the user to change it with a single button press. If another hotkey is already assigned somewhere else it will remove that assignment applying it to only the current clip in context. 

Heres what it looks like:

![image](https://github.com/openAVproductions/openAV-Luppp/assets/28860841/790e4cf7-274e-4eef-a640-3000ceea4601)

This addresses quite a few problems from the previous implementation. One thing was that the hotkeys are not communicated in any way to the user and when first using LUPPP it was a little confusing, especially when not using a US/UK qwerty keyboard. 

As it stands in this PR the new hotkeys are only set for that instance of the application. I want this to persist from one luppp launch to the other and I would like to make the other special keys configurable too in the `setup` menu. To prevent this branch from ballooning too much I think I'm at a point where its good enough to merge. 