### PR TITLE
When JACK buffer size is set above 1024 LUPPP crashes on start

### DIFF
--- a/src/jack.cxx
+++ b/src/jack.cxx
@@ -509,7 +509,7 @@ int Jack::process (jack_nframes_t nframes)
 	buffers.transportFrame = jack_get_current_transport_frame(client);
 
 	if (nframes > 1024) {
-		LUPPP_ERROR("Buffer size too high. Reduce JACK buffer size.");
+		LUPPP_ERROR("Buffer size too high. Reduce JACK buffer size, max 1024.");
 	}
 	// time manager deals with detecting bar() / beat() events, and calls
 	// processFrames() with the appropriate nframes

--- a/src/jack.cxx
+++ b/src/jack.cxx
@@ -508,6 +508,9 @@ int Jack::process (jack_nframes_t nframes)
 	/// update "time" from JACK master, or write master?
 	buffers.transportFrame = jack_get_current_transport_frame(client);
 
+	if (nframes > 1024) {
+		LUPPP_ERROR("Buffer size too high. Reduce JACK buffer size.");
+	}
 	// time manager deals with detecting bar() / beat() events, and calls
 	// processFrames() with the appropriate nframes
 	timeManager->process( &buffers );


### PR DESCRIPTION
Small change to notify the user why LUPPP has crashed when JACK it's buffer size is set over 1024. 