### PR TITLE
Fix error=format-security

### DIFF
--- a/src/gui.cxx
+++ b/src/gui.cxx
@@ -182,7 +182,7 @@ static void gui_header_callback(Fl_Widget *w, void *data)
 	} else if ( strcmp(m->label(), "Save Session   ") == 0 ) {
 		const string projectsDir = gui->getProjectsDir();
 		string prompt = "Save session as " + projectsDir;
-		const char* name = fl_input( prompt.c_str(), gui->getDiskWriter()->getLastSaveName().c_str() );
+		const char* name = fl_input( "%s", gui->getDiskWriter()->getLastSaveName().c_str(), prompt.c_str() );
 		if ( name ) {
 			gui->getDiskWriter()->initialize( projectsDir, name );
 			LUPPP_NOTE("%s %s","Saving session as ", name );


### PR DESCRIPTION
Doesn't build otherwise on my system (gcc 14.2.1 on linux against ntk v1.3.1001 which has the printf format attributes on the fl_input functions)